### PR TITLE
Move some code from the LegacyInitializer to the IJ1Helper

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/LegacyInitializer.java
+++ b/src/main/java/net/imagej/legacy/plugin/LegacyInitializer.java
@@ -32,18 +32,11 @@
 package net.imagej.legacy.plugin;
 
 import ij.IJ;
-import ij.ImageJ;
 
 import java.awt.GraphicsEnvironment;
-import java.awt.Image;
-import java.awt.image.ImageProducer;
-import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.net.URL;
 
 import javax.swing.SwingUtilities;
-
-import net.imagej.patcher.LegacyHooks;
 
 import org.scijava.Context;
 
@@ -88,45 +81,6 @@ public class LegacyInitializer implements Runnable {
 		catch (final Throwable t) {
 			// do nothing; we're not in the PluginClassLoader's class path
 			return;
-		}
-
-		// make sure that the Event Dispatch Thread's class loader is set
-		SwingUtilities.invokeLater(new Runnable() {
-
-			@Override
-			public void run() {
-				Thread.currentThread().setContextClassLoader(IJ.getClassLoader());
-			}
-		});
-
-		// set icon and title of main window (which are instantiated before the
-		// initializer is called)
-		final ImageJ ij = IJ.getInstance();
-		if (ij != null) try {
-			final LegacyHooks hooks =
-				(LegacyHooks) IJ.class.getField("_hooks").get(null);
-			ij.setTitle(hooks.getAppName());
-			final URL iconURL = hooks.getIconURL();
-			if (iconURL != null) try {
-				final Object producer = iconURL.getContent();
-				final Image image = ij.createImage((ImageProducer) producer);
-				ij.setIconImage(image);
-				if (IJ.isMacOSX()) try {
-					// NB: We also need to set the dock icon
-					final Class<?> clazz = Class.forName("com.apple.eawt.Application");
-					final Object app = clazz.getMethod("getApplication").invoke(null);
-					clazz.getMethod("setDockIconImage", Image.class).invoke(app, image);
-				}
-				catch (final Throwable t) {
-					t.printStackTrace();
-				}
-			}
-			catch (final IOException e) {
-				IJ.handleException(e);
-			}
-		}
-		catch (final Throwable t) {
-			t.printStackTrace();
 		}
 	}
 


### PR DESCRIPTION
The current strategy for the legacy mode is to let fiji.Main create
a LegacyEnvironment that patches an encapsulated ImageJ 1.x-only
ClassLoader which in turn creates a PluginClassLoader in which the
LegacyInitializer is called to spin up the ImageJ2 context.

In that setting, it does not matter whether the IJ1Helper (initialized
by the DefaultLegacyService) or whether the LegacyInitializer calls the
code to initialize context class loader, icon and application title.

However, our plan is to let the DefaultLegacyService spin up ImageJ
1.x; In that scenario, the LegacyInitializer is no longer called,
but the IJ1Helper is.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
