### PR TITLE
Be cautious about ImageWindow creation

### DIFF
--- a/src/main/java/net/imagej/legacy/LegacyImageMap.java
+++ b/src/main/java/net/imagej/legacy/LegacyImageMap.java
@@ -180,8 +180,6 @@ public class LegacyImageMap extends AbstractContextual {
 			// mapping does not exist; mirror display to image window
 			imp = imageTranslator.createLegacyImage(display);
 			addMapping(display, imp);
-			// Note - we need to register ImagePlus with IJ1 also
-			new ImageWindow(imp);
 		}
 		return imp;
 	}


### PR DESCRIPTION
Creating a new `ImageWindow` to register a new `ImagePlus` isn't always the right thing to do.

This removes the anonymous `ImageWindow` creation in favor of allowing consuming code to decide how to display (or not) the returned `ImagePlus`.
