### PR TITLE
Defensive programming in DefaultLegacyOpener

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/DefaultLegacyOpener.java
+++ b/src/main/java/net/imagej/legacy/plugin/DefaultLegacyOpener.java
@@ -113,6 +113,7 @@ public class DefaultLegacyOpener implements LegacyOpener {
 				inputs);
 
 		final Module module = moduleService.waitFor(result);
+		if (module == null) return null;
 		if (Cancelable.class.isAssignableFrom(module.getClass())) {
 			if (((Cancelable)module).isCanceled()) {
 				return Boolean.TRUE;


### PR DESCRIPTION
When loading an image via a URL and calling File>Revert, the module
returned by the module service can be null... Symptom:

java.lang.NullPointerException
    at net.imagej.legacy.plugin.DefaultLegacyOpener.open(DefaultLegacyOpener.java:116)
    at net.imagej.legacy.DefaultLegacyHooks.interceptOpen(DefaultLegacyHooks.java:400)
    at ij.IJ.openImage(IJ.java)
    at ij.io.FileOpener.revertToSaved(FileOpener.java:258)
    at ij.ImagePlus.revert(ImagePlus.java:1719)
    at ij.plugin.Commands.revert(Commands.java:53)
    at ij.plugin.Commands.run(Commands.java:35)
    at ij.IJ.runPlugIn(IJ.java:171)
    at ij.Executer.runCommand(Executer.java:131)
    at ij.Executer.run(Executer.java:64)
    at java.lang.Thread.run(Thread.java:701)

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
