### PR TITLE
Hide plugins annotated as invisible

### DIFF
--- a/src/main/java/net/imagej/legacy/DefaultLegacyService.java
+++ b/src/main/java/net/imagej/legacy/DefaultLegacyService.java
@@ -537,6 +537,9 @@ public final class DefaultLegacyService extends AbstractService implements
 			if (info.getMenuPath().size() == 0 || info.is("no-legacy")) {
 				iter.remove();
 			}
+			else if (!info.getAnnotation().visible()) {
+				iter.remove();
+			}
 			else {
 				legacyCompatibleCommands.add(info.getDelegateClassName());
 			}


### PR DESCRIPTION
Small update so that modern plugins with the `visible = false` annotation property are also hidden in the legacy interface.
