### PR TITLE
  Inject Context into LegacyOpeners

### DIFF
--- a/src/main/java/net/imagej/legacy/DefaultLegacyHooks.java
+++ b/src/main/java/net/imagej/legacy/DefaultLegacyHooks.java
@@ -99,10 +99,52 @@ public class DefaultLegacyHooks extends LegacyHooks {
 		return false;
 	}
 
-	private LegacyEditor editor;
-	private LegacyAppConfiguration appConfig;
-	private List<LegacyPostRefreshMenus> afterRefreshMenus;
-	private List<LegacyOpener> legacyOpeners;
+	// TODO: move to SciJava common?
+	private abstract static class AbstractLazySingleton<T> {
+		private T instance;
+
+		public T get() {
+			if (instance != null) return instance;
+			synchronized (this) {
+				if (instance != null) return instance;
+				instance = create();
+				return instance;
+			}
+		}
+
+		protected abstract T create();
+	}
+
+	// TODO: move to SciJava common?
+	private class LazySingleton<T extends SciJavaPlugin> extends AbstractLazySingleton<T> {
+		private final Class<T> type;
+
+		public LazySingleton(Class<T> type) {
+			this.type = type;
+		}
+
+		public T create() {
+			return createInstanceOfType(type);
+		}
+	}
+
+	// TODO: move to SciJava common?
+	private class LazySingletonList<T extends SciJavaPlugin> extends AbstractLazySingleton<List<T>> {
+		private final Class<T> type;
+
+		public LazySingletonList(Class<T> type) {
+			this.type = type;
+		}
+
+		public List<T> create() {
+			return pluginService.createInstancesOfType(type);
+		}
+	}
+
+	private final AbstractLazySingleton<LegacyEditor> editor = new LazySingleton<LegacyEditor>(LegacyEditor.class);
+	private final AbstractLazySingleton<LegacyAppConfiguration> appConfig = new LazySingleton<LegacyAppConfiguration>(LegacyAppConfiguration.class);
+	private final AbstractLazySingleton<List<LegacyPostRefreshMenus>> afterRefreshMenus = new LazySingletonList<LegacyPostRefreshMenus>(LegacyPostRefreshMenus.class);
+	private final AbstractLazySingleton<List<LegacyOpener>> legacyOpeners = new LazySingletonList<LegacyOpener>(LegacyOpener.class);
 
 	/** inherit */
 	@Override
@@ -112,18 +154,6 @@ public class DefaultLegacyHooks extends LegacyHooks {
 		pluginService = context.getService(PluginService.class);
 		log = context.getService(LogService.class);
 		if (log == null) log = new StderrLogService();
-
-		editor = createInstanceOfType(LegacyEditor.class);
-		appConfig = createInstanceOfType(LegacyAppConfiguration.class);
-		// TODO: inject context automatically?
-		afterRefreshMenus = pluginService.createInstancesOfType(LegacyPostRefreshMenus.class);
-		for (final LegacyPostRefreshMenus o : afterRefreshMenus) {
-			context.inject(o);
-		}
-		legacyOpeners = pluginService.createInstancesOfType(LegacyOpener.class);
-		for (final LegacyOpener o : legacyOpeners) {
-			context.inject(o);
-		}
 	}
 
 	// TODO: move to scijava-common?
@@ -302,7 +332,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 	 */
 	@Override
 	public String getAppName() {
-		return appConfig == null ? "ImageJ (legacy)" : appConfig.getAppName();
+		return appConfig.get() == null ? "ImageJ (legacy)" : appConfig.get().getAppName();
 	}
 
 	/**
@@ -325,16 +355,14 @@ public class DefaultLegacyHooks extends LegacyHooks {
 	 */
 	@Override
 	public URL getIconURL() {
-		return appConfig == null ? getClass().getResource("/icons/imagej-256.png") : appConfig.getIconURL();
+		return appConfig.get() == null ? getClass().getResource("/icons/imagej-256.png") : appConfig.get().getIconURL();
 	}
 
 	/** @inherit */
 	@Override
 	public void runAfterRefreshMenus() {
-		if (afterRefreshMenus != null) {
-			for (final Runnable run : afterRefreshMenus) {
-				run.run();
-			}
+		for (final Runnable run : afterRefreshMenus.get()) {
+			run.run();
 		}
 	}
 
@@ -346,7 +374,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 	 */
 	@Override
 	public boolean openInEditor(final String path) {
-		if (editor == null) return false;
+		if (editor.get() == null) return false;
 		if (path.indexOf("://") > 0) return false;
 		// if it has no extension, do not open it in the legacy editor
 		if (!path.matches(".*\\.[0-9A-Za-z]{1,4}")) return false;
@@ -354,7 +382,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 		final File file = new File(path);
 		if (!file.exists()) return false;
 		if (isBinaryFile(file)) return false;
-		return editor.open(file);
+		return editor.get().open(file);
 	}
 
 	/**
@@ -366,8 +394,8 @@ public class DefaultLegacyHooks extends LegacyHooks {
 	 */
 	@Override
 	public boolean createInEditor(final String title, final String content) {
-		if (editor == null) return false;
-		return editor.create(title, content);
+		if (editor.get() == null) return false;
+		return editor.get().create(title, content);
 	}
 
 	/**
@@ -420,7 +448,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 	public Object interceptOpen(final String path, final int planeIndex,
 		final boolean display)
 	{
-		for (final LegacyOpener opener : legacyOpeners) {
+		for (final LegacyOpener opener : legacyOpeners.get()) {
 			final Object result = opener.open(path, planeIndex, display);
 			if (result != null) return result;
 		}
@@ -430,7 +458,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 	/** @inherit */
 	@Override
 	public Object interceptFileOpen(final String path) {
-		for (final LegacyOpener opener : legacyOpeners) {
+		for (final LegacyOpener opener : legacyOpeners.get()) {
 			final Object result = opener.open(path, -1, true);
 			if (result != null) return result;
 		}
@@ -440,7 +468,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 	/** @inherit */
 	@Override
 	public Object interceptOpenImage(final String path, final int planeIndex) {
-		for (final LegacyOpener opener : legacyOpeners) {
+		for (final LegacyOpener opener : legacyOpeners.get()) {
 			final Object result = opener.open(path, planeIndex, false);
 			if (result != null) return result;
 		}
@@ -450,7 +478,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 	/** @inherit */
 	@Override
 	public Object interceptOpenRecent(final String path) {
-		for (final LegacyOpener opener : legacyOpeners) {
+		for (final LegacyOpener opener : legacyOpeners.get()) {
 			final Object result = opener.open(path, -1, true);
 			if (result != null) return result;
 		}
@@ -464,7 +492,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 		String path;
 		try {
 			path = f.getCanonicalPath();
-			for (final LegacyOpener opener : legacyOpeners) {
+			for (final LegacyOpener opener : legacyOpeners.get()) {
 				final Object result = opener.open(path, -1, true);
 				if (result != null) return result;
 			}

--- a/src/main/java/net/imagej/legacy/plugin/DefaultLegacyOpener.java
+++ b/src/main/java/net/imagej/legacy/plugin/DefaultLegacyOpener.java
@@ -42,13 +42,11 @@ import java.util.concurrent.Future;
 import net.imagej.Dataset;
 import net.imagej.display.ImageDisplay;
 import net.imagej.legacy.DefaultLegacyService;
-import net.imagej.legacy.IJ1Helper;
 import net.imagej.legacy.ImageJ2Options;
 import net.imagej.legacy.translate.DefaultImageTranslator;
 import net.imagej.legacy.translate.ImageTranslator;
 
 import org.scijava.Cancelable;
-import org.scijava.Context;
 import org.scijava.Priority;
 import org.scijava.app.App;
 import org.scijava.app.AppService;
@@ -61,8 +59,8 @@ import org.scijava.log.LogService;
 import org.scijava.module.Module;
 import org.scijava.module.ModuleService;
 import org.scijava.options.OptionsService;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.service.Service;
 
 /**
  * The default {@link LegacyOpener} plugin.
@@ -77,30 +75,35 @@ import org.scijava.service.Service;
 @Plugin(type = LegacyOpener.class, priority = Priority.LOW_PRIORITY)
 public class DefaultLegacyOpener implements LegacyOpener {
 
+	@Parameter
 	private DefaultLegacyService legacyService;
+
+	@Parameter
 	private DisplayService displayService;
+
+	@Parameter
 	private ModuleService moduleService;
+
+	@Parameter
 	private CommandService commandService;
+
+	@Parameter
 	private OptionsService optionsService;
+
+	@Parameter
 	private AppService appService;
+
+	@Parameter
 	private IOService ioService;
+
+	@Parameter
 	private LogService logService;
 
 	@Override
 	public Object open(String path, final int planeIndex,
 		final boolean displayResult)
 	{
-		final Context c = IJ1Helper.getLegacyContext();
 		ImagePlus imp = null;
-
-		legacyService = getCached(legacyService, DefaultLegacyService.class, c);
-		displayService = getCached(displayService, DisplayService.class, c);
-		moduleService = getCached(moduleService, ModuleService.class, c);
-		commandService = getCached(commandService, CommandService.class, c);
-		optionsService = getCached(optionsService, OptionsService.class, c);
-		appService = getCached(appService, AppService.class, c);
-		ioService = getCached(ioService, IOService.class, c);
-		logService = getCached(logService, LogService.class, c);
 
 		// Check to see if SCIFIO has been disabled
 		Boolean useSCIFIO = optionsService.getOptions(ImageJ2Options.class).isUseSCIFIO();
@@ -186,12 +189,5 @@ public class DefaultLegacyOpener implements LegacyOpener {
 			return data;
 		}
 		return path;
-	}
-
-	// -- Helper methods --
-
-	private <T extends Service> T getCached(T service, Class<T> serviceClass, Context ctx) {
-		if (service != null) return service;
-		return ctx.getService(serviceClass);
 	}
 }


### PR DESCRIPTION
It is better to support `@Parameter` fields in `LegacyOpeners` than to ask the openers to discover context and services themselves.

It also makes things safer because legacy openers lacking required services will no longer take precedence over legacy openers not having that problem.

This fixes #24.