### PR TITLE
IJ1Helper: add defensive programming for EDT

### DIFF
--- a/src/main/java/net/imagej/legacy/IJ1Helper.java
+++ b/src/main/java/net/imagej/legacy/IJ1Helper.java
@@ -774,6 +774,9 @@ public class IJ1Helper extends AbstractContextual {
 	 * @return the return value
 	 */
 	public String runMacro(final String macro) {
+		if (EventQueue.isDispatchThread()) {
+			throw new IllegalStateException("Cannot run macro from the EDT!");
+		}
 		final Thread thread = Thread.currentThread();
 		final String name = thread.getName();
 		try {
@@ -794,6 +797,9 @@ public class IJ1Helper extends AbstractContextual {
 	 * @return the return value
 	 */
 	public String runMacroFile(final String path, final String arg) {
+		if (EventQueue.isDispatchThread()) {
+			throw new IllegalStateException("Cannot run macro from the EDT!");
+		}
 		final Thread thread = Thread.currentThread();
 		final String name = thread.getName();
 		try {


### PR DESCRIPTION
This avoids deadlocks in favor of failing fast, when something
attempts to run a macro directly from the event dispatch thread.
