### PR TITLE
IJ1MacroEngine: type boolean parameters properly

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/IJ1MacroEngine.java
+++ b/src/main/java/net/imagej/legacy/plugin/IJ1MacroEngine.java
@@ -97,7 +97,7 @@ public class IJ1MacroEngine extends AbstractScriptEngine {
 				} else if (value instanceof File) {
 					value = ((File) value).getAbsolutePath();
 				}
-				if (value instanceof Number) {
+				if (value instanceof Number || value instanceof Boolean) {
 					pre.append(key).append(" = ").append(value).append(";\n");
 				} else {
 					String quoted = quote(value.toString());


### PR DESCRIPTION
Previously, these was no special case for injecting a boolean parameter into an ImageJ1 macro, so it got converted to a string.

Thanks to Benoit Lombardot for [noticing](https://list.nih.gov/cgi-bin/wa.exe?A2=IMAGEJ;7b6768c4.1503).