### PR TITLE
Fix the `-batch <file>` handling

### DIFF
--- a/src/main/java/net/imagej/legacy/LegacyCommandline.java
+++ b/src/main/java/net/imagej/legacy/LegacyCommandline.java
@@ -198,10 +198,10 @@ public abstract class LegacyCommandline extends AbstractConsoleArgument {
 		public void handle(LinkedList<String> args) {
 			if (!supports(args)) return;
 
+			handleBatchOption(args);
 			args.removeFirst(); // -batch or -batch-no-exit
 
-			handleBatchOption(args);
-			if (args.size() > 1) {
+			if (args.size() > 0) {
 				final String path = args.removeFirst();
 				final String arg = args.isEmpty() ? "" : args.removeFirst();
 				ij1Helper().runMacroFile(path, arg);


### PR DESCRIPTION
Triggered by a tweet of Stephan Preibisch, this developer tried to run a
macro in batch mode via

	.../ImageJ-win32 -batch abc.ijm

and was surprised that it did not work. The reason it did not work was a
completely borked logic behind the `-batch` handling, which assumed that
`.../ImageJ-win32 -eval ... -batch` was the only use case.

This patch fixes that logic to work correctly.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>