### PR TITLE
Reinstate ImageJ 1.x' "single instance listener"

### DIFF
--- a/src/main/java/net/imagej/legacy/IJ1Helper.java
+++ b/src/main/java/net/imagej/legacy/IJ1Helper.java
@@ -437,6 +437,15 @@ public class IJ1Helper extends AbstractContextual {
 	}
 
 	/**
+	 * Opens an image and adds the path to the <it>File>Open Recent</it> menu.
+	 * 
+	 * @param file the image to open
+	 */
+	public static void openAndAddToRecent(final File file) {
+		new Opener().openAndAddToRecent(file.getAbsolutePath());
+	}
+
+	/**
 	 * Records an option in ImageJ 1.x's macro recorder.
 	 * 
 	 * @param key the name of the option
@@ -559,7 +568,7 @@ public class IJ1Helper extends AbstractContextual {
 			if (isLegacyMode()) {
 				final List<File> files = new ArrayList<File>(event.getFiles());
 				for (final File file : files) {
-					new Opener().openAndAddToRecent(file.getAbsolutePath());
+					openAndAddToRecent(file);
 				}
 			}
 		}

--- a/src/main/java/net/imagej/legacy/IJ1Helper.java
+++ b/src/main/java/net/imagej/legacy/IJ1Helper.java
@@ -933,7 +933,19 @@ public class IJ1Helper extends AbstractContextual {
 	 * @return the image
 	 */
 	public Object openImage(final String path) {
-		return IJ.openImage(path);
+		return openImage(path, false);
+	}
+
+	/**
+	 * Opens an image using ImageJ 1.x.
+	 * 
+	 * @param path the image file to open
+	 * @return the image
+	 */
+	public Object openImage(final String path, final boolean show) {
+		final ImagePlus imp = IJ.openImage(path);
+		if (show && imp != null) imp.show();
+		return imp;
 	}
 
 	/**

--- a/src/main/java/net/imagej/legacy/IJ1Helper.java
+++ b/src/main/java/net/imagej/legacy/IJ1Helper.java
@@ -37,6 +37,7 @@ import ij.ImageJ;
 import ij.ImagePlus;
 import ij.Macro;
 import ij.Menus;
+import ij.OtherInstance;
 import ij.WindowManager;
 import ij.gui.ImageWindow;
 import ij.gui.Toolbar;
@@ -238,6 +239,15 @@ public class IJ1Helper extends AbstractContextual {
 		final ImageJ ij = IJ.getInstance();
 		if (ij == null) return false;
 		return ij.isVisible();
+	}
+
+	/**
+	 * Determines whether <it>Edit>Options>Misc...>Run single instance listener</it> is set.
+	 * 
+	 * @return true if <it>Run single instance listener</it> is set
+	 */
+	public boolean isRMIEnabled() {
+		return OtherInstance.isRMIEnabled();
 	}
 
 	private boolean batchMode;
@@ -871,6 +881,21 @@ public class IJ1Helper extends AbstractContextual {
 	}
 
 	/**
+	 * Evaluates the specified command.
+	 * 
+	 * @param command the command to execute
+	 */
+	public void run(final String command) {
+		runMacroFriendly("macro", new Callable<Void>() {
+			@Override
+			public Void call() throws Exception {
+				IJ.run(command);
+				return null;
+			}
+		});
+	}
+
+	/**
 	 * Evaluates the specified macro.
 	 * 
 	 * @param macro the macro to evaluate
@@ -980,6 +1005,11 @@ public class IJ1Helper extends AbstractContextual {
 		if (legacyService.isLegacyMode()) {
 			IJ.run("About ImageJ...");
 		}
+	}
+
+	/** Sets OpenDialog's default directory */
+	public void setDefaultDirectory(final File directory) {
+		OpenDialog.setDefaultDirectory(directory.getPath());
 	}
 
 	/** Uses ImageJ 1.x' OpenDialog */

--- a/src/main/java/net/imagej/legacy/LegacyCommandline.java
+++ b/src/main/java/net/imagej/legacy/LegacyCommandline.java
@@ -111,6 +111,11 @@ public abstract class LegacyCommandline extends AbstractConsoleArgument {
 		return legacyService.getIJ1Helper();
 	}
 
+	protected boolean isBatchMode() {
+		final Boolean b = batchMode.get(legacyService);
+		return b != null && b.booleanValue();
+	}
+
 	protected void handleBatchOption(final LinkedList<String> args) {
 		if (args.isEmpty() || batchMode.get(legacyService) != null) return;
 		if (args.contains("-batch-no-exit")) {
@@ -155,7 +160,7 @@ public abstract class LegacyCommandline extends AbstractConsoleArgument {
 			final String path = args.removeFirst(); // "file-name"
 
 			handleBatchOption(args);
-			ij1Helper().openImage(path);
+			ij1Helper().openImage(path, !isBatchMode());
 			handleBatchExit(args);
 		}
 

--- a/src/main/java/net/imagej/legacy/LegacyCommandline.java
+++ b/src/main/java/net/imagej/legacy/LegacyCommandline.java
@@ -30,6 +30,7 @@
  */
 package net.imagej.legacy;
 
+import java.awt.GraphicsEnvironment;
 import java.util.LinkedList;
 import java.util.WeakHashMap;
 
@@ -160,7 +161,7 @@ public abstract class LegacyCommandline extends AbstractConsoleArgument {
 			final String path = args.removeFirst(); // "file-name"
 
 			handleBatchOption(args);
-			ij1Helper().openImage(path, !isBatchMode());
+			ij1Helper().openImage(path, !GraphicsEnvironment.isHeadless() && !isBatchMode());
 			handleBatchExit(args);
 		}
 

--- a/src/main/java/net/imagej/legacy/LegacyConsoleService.java
+++ b/src/main/java/net/imagej/legacy/LegacyConsoleService.java
@@ -1,0 +1,89 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.legacy;
+
+import org.scijava.Priority;
+import org.scijava.console.DefaultConsoleService;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.service.Service;
+
+@Plugin(type = Service.class, priority = Priority.HIGH_PRIORITY)
+public class LegacyConsoleService extends DefaultConsoleService {
+
+	@Parameter
+	private LegacyService legacy;
+
+	@Parameter
+	private LogService log;
+
+	private int port = 7;
+
+	@Override
+	public void processArgs(final String... args) {
+		if (legacy != null && singleInstancePermissible(args)) {
+			final IJ1Helper helper = legacy.getIJ1Helper();
+			if (helper != null) {
+				final SingleInstance instance = new SingleInstance(port, log, helper);
+				if (helper.isRMIEnabled() && instance.sendArguments(args)) {
+					context().dispose();
+					System.exit(0);
+				}
+			}
+		}
+
+		super.processArgs(args);
+	}
+
+	/**
+	 * Detects arguments that prevent handing off to existing instances.
+	 * 
+	 * @param args arguments, as passed to the console service
+	 * @return true if we should look for an existing instance to use
+	 */
+	private boolean singleInstancePermissible(final String... args) {
+		for (final String arg : args) {
+			// should not happen, but we're not called by main() but by processArgs()
+			if (arg == null) continue;
+			if (arg.equals("-batch") || arg.equals("-ijpath")) return false;
+			if (arg.startsWith("-port")) try {
+				port = Integer.parseInt(arg.substring(5), 10);
+				if (port == 0) return false;
+			} catch (NumberFormatException e) {
+				// ImageJ1 parses these as 0, disabling the single instance functionality
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/src/main/java/net/imagej/legacy/SingleInstance.java
+++ b/src/main/java/net/imagej/legacy/SingleInstance.java
@@ -1,0 +1,216 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.legacy;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+import java.rmi.server.UnicastRemoteObject;
+
+import org.scijava.log.LogService;
+
+/**
+ * This class tries to contact another instance on the same machine, started
+ * by the current user. If such an instance is found, the arguments are
+ * sent to that instance. If no such an instance is found, listen for clients.
+ * 
+ * No need for extra security, as the stub (and its serialization) contain
+ * a hard-to-guess hash code.
+ *
+ *@author Johannes Schindelin
+ */
+public class SingleInstance {
+
+	private final int port;
+	private final LogService log;
+	private final IJ1Helper helper;
+	private final boolean isWindows;
+
+	public SingleInstance(final int port, final LogService log, final IJ1Helper helper) {
+		this.port = port;
+		this.log = log;
+		this.helper = helper;
+		final String osName = System.getProperty("os.name");
+		isWindows = osName != null && osName.toLowerCase().indexOf("win") >= 0;
+	}
+
+	private interface ImageJInstance extends Remote {
+		void sendArgument(String arg) throws RemoteException;
+	}
+
+	private class Implementation implements ImageJInstance {
+		public void sendArgument(String cmd) {
+			log.debug("SocketServer.sendArgument: \""+ cmd+"\"");
+			if (cmd.startsWith("open "))
+				IJ1Helper.openAndAddToRecent(new File(cmd.substring(5)));
+			else if (cmd.startsWith("macro ")) {
+				String name = cmd.substring(6);
+				String name2 = name;
+				String arg = null;
+				if (name2.endsWith(")")) {
+					int index = name2.lastIndexOf("(");
+					if (index>0) {
+						name = name2.substring(0, index);
+						arg = name2.substring(index+1, name2.length()-1);
+					}
+				}
+				helper.runMacroFile(name, arg);
+			} else if (cmd.startsWith("run "))
+				helper.run(cmd.substring(4));
+			else if (cmd.startsWith("eval ")) {
+				String rtn = helper.runMacro(cmd.substring(5));
+				if (rtn!=null)
+					System.out.print(rtn);
+			} else if (cmd.startsWith("user.dir "))
+				helper.setDefaultDirectory(new File(cmd.substring(9)));
+		}
+	}
+
+	public String getStubPath() {
+		String display = System.getenv("DISPLAY");
+		if (display != null) {
+			// avoid problems with non-existing directories
+			display = display.replace(':', '_');
+			display = display.replace('/', '_');
+		}
+		String tmpDir = System.getProperty("java.io.tmpdir");
+		if (!tmpDir.endsWith(File.separator))
+			tmpDir = tmpDir + File.separator;
+
+		return tmpDir + "ImageJ-"
+			+ System.getProperty("user.name") + "-"
+			+ (display == null ? "" : display + "-")
+			+ port + ".stub";
+	}
+
+	public void makeFilePrivate(String path) {
+		try {
+			File file = new File(path);
+			file.deleteOnExit();
+
+			file.setReadable(true, true);
+			file.setWritable(false);
+			return;
+		} catch (Exception e) {
+			log.error("Java < 6 detected," + " trying chmod 0600 " + path, e);
+		}
+
+		if (!isWindows) {
+			try {
+				String[] command = {
+					"chmod", "0600", path
+				};
+				Runtime.getRuntime().exec(command);
+			} catch (Exception e) {
+				log.error("Even chmod failed.", e);
+			}
+		}
+	}
+
+	public boolean sendArguments(String[] args) {
+		if (!helper.isRMIEnabled())
+			return false;
+		String file = getStubPath();
+		if (args.length > 0) try {
+			FileInputStream in = new FileInputStream(file);
+			ImageJInstance instance = (ImageJInstance) new ObjectInputStream(in).readObject();
+			in.close();
+			if (instance==null)
+				return false;
+
+			//IJ.log("sendArguments3: "+instance);
+			instance.sendArgument("user.dir "+System.getProperty("user.dir"));
+			int macros = 0;
+			for (int i=0; i<args.length; i++) {
+				String arg = args[i];
+				if (arg==null) continue;
+				String cmd = null;
+				if (macros==0 && arg.endsWith(".ijm")) {
+					cmd = "macro " + arg;
+					macros++;
+				} else if (arg.startsWith("-macro") && i+1<args.length) {
+					String macroArg = i+2<args.length?"("+args[i+2]+")":"";
+					cmd = "macro " + args[i+1] + macroArg;
+					instance.sendArgument(cmd);
+					break;
+				} else if (arg.startsWith("-eval") && i+1<args.length) {
+					cmd = "eval " + args[i+1];
+					args[i+1] = null;
+				} else if (arg.startsWith("-run") && i+1<args.length) {
+					cmd = "run " + args[i+1];
+					args[i+1] = null;
+				} else if (arg.indexOf("ij.ImageJ")==-1 && !arg.startsWith("-"))
+					cmd = "open " + arg;
+				if (cmd!=null)
+					instance.sendArgument(cmd);
+			}
+
+			log.debug("sendArguments: return true");
+			return true;
+		} catch (FileNotFoundException e) {
+			// ignore silently
+		} catch (Exception e) {
+			log.error(e);
+			new File(file).delete();
+		}
+		if (!new File(file).exists())
+			startServer();
+		log.debug("sendArguments: return false ");
+		return false;
+	}
+
+	static ImageJInstance stub;
+	static Implementation implementation;
+
+	private void startServer() {
+		log.debug("OtherInstance: starting server");
+		try {
+			implementation = new Implementation();
+			stub = (ImageJInstance)UnicastRemoteObject.exportObject(implementation, 0);
+
+			// Write serialized object
+			String path = getStubPath();
+			FileOutputStream out = new FileOutputStream(path);
+			makeFilePrivate(path);
+			new ObjectOutputStream(out).writeObject(stub);
+			out.close();
+
+			log.debug("OtherInstance: server ready");
+		} catch (Exception e) {
+			log.error(e);
+		}
+	}
+}


### PR DESCRIPTION
In ImageJ 1.x, there is an option *Options>Misc...>Run single instance listener*; When checked, it tells ImageJ to look for an existing ImageJ instance when starting up, and passing the command-line options if one is found. Essentially, it makes ImageJ behave like a singleton.

This Pull Request reinstates that functionality and fixes a few issues related to it. The work has been sponsored by Zeiss Deutschland to ensure interoperability between Fiji and ZEN.