### PR TITLE
Add check if file parameter is null

### DIFF
--- a/src/main/java/net/imagej/legacy/IJ1Helper.java
+++ b/src/main/java/net/imagej/legacy/IJ1Helper.java
@@ -1063,9 +1063,11 @@ public class IJ1Helper extends AbstractContextual {
 
 	/** Chooses a directory using ImageJ 1.x' directory chooser. */
 	public String getDirectory(final String title, final File file) {
-		final String defaultDir =
-			file.isDirectory() ? file.getPath() : file.getParent();
-		DirectoryChooser.setDefaultDirectory(defaultDir);
+		if (file != null) {
+			final String defaultDir =
+				file.isDirectory() ? file.getPath() : file.getParent();
+			DirectoryChooser.setDefaultDirectory(defaultDir);
+		}
 
 		return new DirectoryChooser(title).getDirectory();
 	}


### PR DESCRIPTION
This prevents an exception being thrown when using a @File parameter with `style = "directory"` but no default value defined.

This macro demonstrates the issue:
```
// @File(label = "Choose a folder", style = "directory") myDir

print(myDir);
```

The following exception is thrown without this fix:
```
java.lang.reflect.InvocationTargetException
	at java.awt.EventQueue.invokeAndWait(EventQueue.java:1043)
	at org.scijava.thread.DefaultThreadService.invoke(DefaultThreadService.java:111)
	at net.imagej.legacy.ui.LegacyUI.chooseFile(LegacyUI.java:290)
	at org.scijava.ui.DefaultUIService.chooseFile(DefaultUIService.java:329)
	at org.scijava.ui.FilePreprocessor.process(FilePreprocessor.java:70)
	at org.scijava.module.ModuleRunner.preProcess(ModuleRunner.java:104)
	at org.scijava.module.ModuleRunner.run(ModuleRunner.java:156)
	at org.scijava.module.ModuleRunner.call(ModuleRunner.java:126)
	at org.scijava.module.ModuleRunner.call(ModuleRunner.java:65)
	at org.scijava.thread.DefaultThreadService$2.call(DefaultThreadService.java:191)
	at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:303)
	at java.util.concurrent.FutureTask.run(FutureTask.java:138)
	at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
	at java.lang.Thread.run(Thread.java:662)
Caused by: java.lang.NullPointerException
	at net.imagej.legacy.IJ1Helper.getDirectory(IJ1Helper.java:1066)
	at net.imagej.legacy.ui.LegacyUI$2.run(LegacyUI.java:296)
	at org.scijava.thread.DefaultThreadService$1.run(DefaultThreadService.java:174)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:199)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:642)
	at java.awt.EventQueue.access$000(EventQueue.java:85)
	at java.awt.EventQueue$1.run(EventQueue.java:603)
	at java.awt.EventQueue$1.run(EventQueue.java:601)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.AccessControlContext$1.doIntersectionPrivilege(AccessControlContext.java:87)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:612)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:269)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:184)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:174)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:169)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:161)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:122)

```