### PR TITLE
Improve reliability of getActiveImageDisplay

### DIFF
--- a/src/main/java/net/imagej/legacy/display/LegacyImageDisplayService.java
+++ b/src/main/java/net/imagej/legacy/display/LegacyImageDisplayService.java
@@ -118,7 +118,10 @@ public class LegacyImageDisplayService extends AbstractService implements
 		if (imp != null) {
 			imageDisplay = getImageMap().registerLegacyImage(imp);
 		}
-		return imageDisplay;
+		if (imageDisplay != null)
+			return imageDisplay;
+		// Try the delegate ImageDisplayService if the WindowManager fails
+		return imageDisplayService().getActiveImageDisplay();
 	}
 
 	@Override


### PR DESCRIPTION
If the WindowManager could not find any active ImageDisplay, the
delegate ImageDisplayService's method is called.
