### PR TITLE
ImageJ2Options: add log level selection

### DIFF
--- a/src/main/java/net/imagej/legacy/ImageJ2Options.java
+++ b/src/main/java/net/imagej/legacy/ImageJ2Options.java
@@ -75,21 +75,19 @@ public class ImageJ2Options extends OptionsPlugin implements Interactive {
 	 * This system leverages the <a href="http://imagej.net/SCIFIO">SCIFIO</a>
 	 * library to open image files.
 	 */
-	@Parameter(
-		label = "Use SCIFIO when opening files (BETA!)",
-		description = "<html>Whether to use ImageJ2's file I/O mechanism when "
-			+ "opening files.<br>Image files will be opened using the SCIFIO library "
-			+ "(SCientific Image<br>Format Input and Output), which provides truly "
-			+ "extensible support for<br>reading and writing image file formats.",
+	@Parameter(label = "Use SCIFIO when opening files (BETA!)",
+		description = "<html>Whether to use ImageJ2's file I/O mechanism when " +
+			"opening files.<br>Image files will be opened using the SCIFIO library " +
+			"(SCientific Image<br>Format Input and Output), which provides truly " +
+			"extensible support for<br>reading and writing image file formats.",
 		callback = "run")
 	private boolean sciJavaIO = false;
 
-	@Parameter(
-		label = "SciJava log level",
+	@Parameter(label = "SciJava log level",
 		description = "<html>Log level for SciJava",
-		initializer = "initializeLogLevel",
-		callback = "setLogLevel",
-		choices = {"ERROR", "WARN", "INFO", "DEBUG", "TRACE"},
+		initializer = "initializeLogLevel", //
+		callback = "setLogLevel", //
+		choices = { "ERROR", "WARN", "INFO", "DEBUG", "TRACE" }, //
 		persist = false)
 	private String logLevel;
 

--- a/src/main/java/net/imagej/legacy/ImageJ2Options.java
+++ b/src/main/java/net/imagej/legacy/ImageJ2Options.java
@@ -89,7 +89,8 @@ public class ImageJ2Options extends OptionsPlugin implements Interactive {
 		description = "<html>Log level for SciJava",
 		initializer = "initializeLogLevel",
 		callback = "setLogLevel",
-		choices = {"ERROR", "WARN", "INFO", "DEBUG", "TRACE"})
+		choices = {"ERROR", "WARN", "INFO", "DEBUG", "TRACE"},
+		persist = false)
 	private String logLevel;
 
 	@Parameter(label = "What is ImageJ2?", persist = false, callback = "help")

--- a/src/main/java/net/imagej/legacy/ImageJ2Options.java
+++ b/src/main/java/net/imagej/legacy/ImageJ2Options.java
@@ -84,6 +84,13 @@ public class ImageJ2Options extends OptionsPlugin implements Interactive {
 		callback = "run")
 	private boolean sciJavaIO = false;
 
+	@Parameter(
+		label = "SciJava log level",
+		description = "<html>Log level for SciJava",
+		callback = "setLogLevel",
+		choices = {"ERROR", "WARN", "INFO", "DEBUG", "TRACE"})
+	private String logLevel = "WARN";
+
 	@Parameter(label = "What is ImageJ2?", persist = false, callback = "help")
 	private Button help;
 
@@ -200,5 +207,29 @@ public class ImageJ2Options extends OptionsPlugin implements Interactive {
 		else {
 			System.err.println(message);
 		}
+	}
+
+	@SuppressWarnings("unused")
+	private void setLogLevel() {
+		log.setLevel(parseLogLevel(logLevel));
+	}
+
+	/**
+	 * Parses a log level from a {@code String}.
+	 * 
+	 * @param level
+	 * @return the {@code int} associated with the level
+	 */
+	private int parseLogLevel(final String level) {
+		switch (level) {
+			case "NONE": return LogService.NONE;
+			case "ERROR": return LogService.ERROR;
+			case "WARN": return LogService.WARN;
+			case "INFO": return LogService.INFO;
+			case "DEBUG": return LogService.DEBUG;
+			case "TRACE": return LogService.TRACE;
+		}
+
+		return LogService.WARN;
 	}
 }

--- a/src/main/java/net/imagej/legacy/ImageJ2Options.java
+++ b/src/main/java/net/imagej/legacy/ImageJ2Options.java
@@ -87,9 +87,10 @@ public class ImageJ2Options extends OptionsPlugin implements Interactive {
 	@Parameter(
 		label = "SciJava log level",
 		description = "<html>Log level for SciJava",
+		initializer = "initializeLogLevel",
 		callback = "setLogLevel",
 		choices = {"ERROR", "WARN", "INFO", "DEBUG", "TRACE"})
-	private String logLevel = "WARN";
+	private String logLevel;
 
 	@Parameter(label = "What is ImageJ2?", persist = false, callback = "help")
 	private Button help;
@@ -210,6 +211,11 @@ public class ImageJ2Options extends OptionsPlugin implements Interactive {
 	}
 
 	@SuppressWarnings("unused")
+	private void initializeLogLevel() {
+		logLevel = parseLogLevel(log.getLevel());
+	}
+
+	@SuppressWarnings("unused")
 	private void setLogLevel() {
 		log.setLevel(parseLogLevel(logLevel));
 	}
@@ -231,5 +237,28 @@ public class ImageJ2Options extends OptionsPlugin implements Interactive {
 		}
 
 		return LogService.WARN;
+	}
+
+	/**
+	 * Parses a log level from an {@code int}.
+	 * 
+	 * @param level
+	 * @return the {@code String} associated with the level
+	 */
+	private String parseLogLevel(int level) {
+		if (level == LogService.NONE)
+			return "NONE";
+		if (level == LogService.ERROR)
+			return "ERROR";
+		if (level == LogService.WARN)
+			return "WARN";
+		if (level == LogService.INFO)
+			return "INFO";
+		if (level == LogService.DEBUG)
+			return "DEBUG";
+		if (level == LogService.TRACE)
+			return "TRACE";
+
+		return "" + level;
 	}
 }


### PR DESCRIPTION
Add selection of the SciJava log level to the ImageJ2 options dialog.

**Known issues:**
- [x] Doesn't set the drop down's default value to the currently active log level. Is there a possibility to access the generated widget from an `initialize()` method?
- Could `LogService.WARN`, etc, be implemented as an enum?
