### PR TITLE
Bugfix: file order

### DIFF
--- a/src/main/resources/script_templates/ImageJ_1.x/Examples/Process_Folder.ijm
+++ b/src/main/resources/script_templates/ImageJ_1.x/Examples/Process_Folder.ijm
@@ -14,6 +14,7 @@ processFolder(input);
 // function to scan folders/subfolders/files to find files with correct suffix
 function processFolder(input) {
 	list = getFileList(input);
+	list = Array.sort(list)
 	for (i = 0; i < list.length; i++) {
 		if(File.isDirectory(input + list[i]))
 			processFolder("" + input + list[i]);

--- a/src/main/resources/script_templates/ImageJ_1.x/Examples/Process_Folder.py
+++ b/src/main/resources/script_templates/ImageJ_1.x/Examples/Process_Folder.py
@@ -14,6 +14,7 @@ def run():
   srcDir = srcFile.getAbsolutePath()
   dstDir = dstFile.getAbsolutePath()
   for root, directories, filenames in os.walk(srcDir):
+    filenames.sort();
     for filename in filenames:
       # Check for file extension
       if not filename.endswith(ext):


### PR DESCRIPTION
Hey guys,

we just had the issue that the file order is random on some systems (Linux, Windows). Thus, if you program a script processing an image sequence on MacOS it works fine using these templates. However, runnning the same script on Linux resulted in errors because the files were processed in random order. Adding the sort-commands, as shown here, solves the issue.

Best,
Robert