### PR TITLE
Add converter for ResultsTable to GenericTable

### DIFF
--- a/src/main/java/net/imagej/legacy/convert/ResultsTableColumnWrapper.java
+++ b/src/main/java/net/imagej/legacy/convert/ResultsTableColumnWrapper.java
@@ -1,0 +1,326 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.stream.IntStream;
+
+import net.imagej.table.GenericColumn;
+
+import ij.measure.ResultsTable;
+
+/**
+ * Wraps a {@link ResultsTable} column as a {@link GenericColumn}.
+ *
+ * @author Alison Walter
+ */
+public class ResultsTableColumnWrapper extends GenericColumn {
+
+	private final ResultsTable table;
+	private final int col;
+
+	public ResultsTableColumnWrapper(final ResultsTable table, final int col) {
+		this.table = table;
+		this.col = col;
+	}
+
+	@Override
+	public String getHeader() {
+		return table.getColumnHeading(col);
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public void setHeader(final String header) {
+		table.setHeading(col, header);
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return table.getColumn(col) == null;
+	}
+
+	@Override
+	public boolean contains(final Object o) {
+		if (o instanceof Number) {
+			final double value = ((Number) o).doubleValue();
+			for (int i = 0; i < table.size(); i++) {
+				if (table.getValueAsDouble(col, i) == value) return true;
+			}
+			return false;
+		}
+		else if (o instanceof String) {
+			final String value = ((String) o);
+			for (int i = 0; i < table.size(); i++) {
+				if (table.getStringValue(col, i).equals(value)) return true;
+			}
+			return false;
+		}
+		return false;
+	}
+
+	@Override
+	public Iterator<Object> iterator() {
+		throw new UnsupportedOperationException("iterator()");
+	}
+
+	@Override
+	public Object[] toArray() {
+		final Object[] values = new Object[table.size()];
+		for (int i = 0; i < values.length; i++) {
+			if (checkString(i)) values[i] = table.getStringValue(col, i);
+			else values[i] = table.getValueAsDouble(col, i);
+		}
+		return values;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T[] toArray(final T[] a) {
+		final T[] copy = a.length < table.size() ? (T[]) java.lang.reflect.Array
+			.newInstance(a.getClass().getComponentType(), table.size()) : a;
+
+		for (int i = 0; i < table.size(); i++) {
+			if (checkString(i)) copy[i] = (T) table.getStringValue(col, i);
+			else copy[i] = (T) Double.valueOf(table.getValueAsDouble(col, i));
+		}
+		if (copy.length > table.size()) copy[table.size()] = null;
+
+		return copy;
+	}
+
+	/**
+	 * Adds the given object to the end of the column. If the passed object is a
+	 * {@code Number} it will be represented as a double.
+	 */
+	@Override
+	public boolean add(final Object e) {
+		table.incrementCounter(); // addValue does not increment row count
+		if (e instanceof Number) table.addValue(col, ((Number) e).doubleValue());
+		else if (e != null) table.addValue(table.getColumnHeading(col), e
+			.toString());
+		else return false;
+		return true;
+	}
+
+	@Override
+	public boolean remove(final Object o) {
+		throw new UnsupportedOperationException("remove(Object)");
+	}
+
+	@Override
+	public boolean containsAll(final Collection<?> c) {
+		for (final Object o : c) {
+			if (!contains(o)) return false;
+		}
+		return true;
+	}
+
+	@Override
+	public boolean addAll(final Collection<? extends Object> c) {
+		boolean b = false;
+		for (final Object d : c) {
+			b = b || add(d);
+		}
+		return b;
+	}
+
+	@Override
+	public boolean addAll(final int index, final Collection<? extends Object> c) {
+		throw new UnsupportedOperationException("addAll(int, Collection)");
+	}
+
+	@Override
+	public boolean removeAll(final Collection<?> c) {
+		throw new UnsupportedOperationException("removeAll(Collection)");
+	}
+
+	@Override
+	public boolean retainAll(final Collection<?> c) {
+		throw new UnsupportedOperationException("retainAll(Collection)");
+	}
+
+	@Override
+	public void clear() {
+		// Determine if empty cells are NaN or 0
+		double fill = 0;
+		try {
+			final Field f = ResultsTable.class.getDeclaredField("NaNEmptyCells");
+			f.setAccessible(true);
+			final boolean nan = (boolean) f.get(table);
+			fill = nan ? Double.NaN : 0;
+		}
+		catch (final Exception exc) {
+			// Keep as zero
+		}
+
+		for (int i = 0; i < table.size(); i++) {
+			// set strings to "", this must be done first. Since setting the string
+			// sets the corresponding double value position to NaN
+			table.setValue(col, i, "");
+			table.setValue(col, i, fill);
+		}
+	}
+
+	@Override
+	public Object get(final int index) {
+		if (checkString(index)) return table.getStringValue(col, index);
+		return table.getValueAsDouble(col, index);
+	}
+
+	/**
+	 * Sets the value at the given index. If {@code element} is a {@code Number}
+	 * it will be stored as {@code double}.
+	 */
+	@Override
+	public Object set(final int index, final Object element) {
+		// Store the previous value
+		Object prev = null;
+		if (checkString(index)) prev = table.getStringValue(col, index);
+		else prev = table.getValueAsDouble(col, index);
+
+		// Set the new value
+		if (element instanceof Number) table.setValue(col, index, ((Number) element)
+			.doubleValue());
+		else if (element != null) table.setValue(col, index, element.toString());
+		else throw new NullPointerException();
+
+		return prev;
+	}
+
+	@Override
+	public void add(final int index, final Object element) {
+		throw new UnsupportedOperationException("add(int, Object)");
+	}
+
+	@Override
+	public Double remove(final int index) {
+		throw new UnsupportedOperationException("remove(int)");
+	}
+
+	@Override
+	public int indexOf(final Object o) {
+		return findInRange(o, IntStream.range(0, table.size()));
+	}
+
+	@Override
+	public int lastIndexOf(final Object o) {
+		return findInRange(o, IntStream.range(0, table.size()).map(i -> table
+			.size() - i - 1));
+	}
+
+	@Override
+	public ListIterator<Object> listIterator() {
+		throw new UnsupportedOperationException("listIterator()");
+	}
+
+	@Override
+	public ListIterator<Object> listIterator(final int index) {
+		throw new UnsupportedOperationException("listIterator(int)");
+	}
+
+	@Override
+	public List<Object> subList(final int fromIndex, final int toIndex) {
+		final List<Object> l = new ArrayList<>(toIndex - fromIndex);
+		for (int i = fromIndex; i < toIndex; i++) {
+			if (checkString(i)) l.add(table.getStringValue(col, i));
+			else l.add(table.getValueAsDouble(col, i));
+		}
+		return l;
+	}
+
+	@Override
+	public int size() {
+		return table.size();
+	}
+
+	@Override
+	public void setSize(final int size) {
+		throw new UnsupportedOperationException("setSize(int)");
+	}
+
+	// -- Helper methods --
+
+	/**
+	 * Checks if the value at the given row in the column is a String.
+	 *
+	 * @param row position to check value at in column
+	 * @return true if the value at the given location is a String, otherwise
+	 *         false
+	 */
+	private boolean checkString(final int row) {
+		final double d = table.getValueAsDouble(col, row);
+		final String s = table.getStringValue(col, row);
+
+		// convert d to a string, as ResultsTable would
+		String c = "";
+		try {
+			final Field f = ResultsTable.class.getDeclaredField("decimalPlaces");
+			f.setAccessible(true);
+			final short[] dec = (short[]) f.get(table);
+			final short places = dec[col];
+			if (places == Short.MIN_VALUE) {
+				final Method m = table.getClass().getDeclaredMethod("n", double.class);
+				m.setAccessible(true);
+				c = (String) m.invoke(table, d);
+			}
+			else {
+				c = ResultsTable.d2s(d, dec[col]);
+			}
+		}
+		catch (final Exception exc) {
+			// if can't get the decimal places or n(...), call d2s with AUTO_FORMAT
+			c = ResultsTable.d2s(d, ResultsTable.AUTO_FORMAT);
+		}
+
+		// Special case for NaN
+		if (((Double) d).isNaN() && (s == "" || s == null)) return false;
+
+		return !s.equals(c);
+	}
+
+	private int findInRange(final Object o, final IntStream range) {
+		return range.filter(i -> cellContains(o, i)).findFirst().orElse(-1);
+	}
+
+	private boolean cellContains(final Object o, final int row) {
+		if (o instanceof Number) return ((Number) o).doubleValue() == table
+			.getValueAsDouble(col, row);
+		return o instanceof String && o.equals(table.getStringValue(col, row));
+	}
+}

--- a/src/main/java/net/imagej/legacy/convert/ResultsTableToGenericTableConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/ResultsTableToGenericTableConverter.java
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import net.imagej.table.GenericTable;
+
+import org.scijava.Priority;
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Plugin;
+
+import ij.measure.ResultsTable;
+
+/**
+ * Converts a {@link ResultsTable} to a {@link GenericTable}.
+ *
+ * @author Alison Walter
+ */
+@Plugin(type = Converter.class, priority = Priority.LOW_PRIORITY)
+public class ResultsTableToGenericTableConverter extends
+	AbstractConverter<ResultsTable, GenericTable>
+{
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T convert(final Object src, final Class<T> dest) {
+		if (src == null || dest == null) throw new NullPointerException();
+		if (!(src instanceof ResultsTable)) return null;
+
+		return (T) new ResultsTableWrapper((ResultsTable) src);
+	}
+
+	@Override
+	public Class<GenericTable> getOutputType() {
+		return GenericTable.class;
+	}
+
+	@Override
+	public Class<ResultsTable> getInputType() {
+		return ResultsTable.class;
+	}
+
+}

--- a/src/main/java/net/imagej/legacy/convert/ResultsTableWrapper.java
+++ b/src/main/java/net/imagej/legacy/convert/ResultsTableWrapper.java
@@ -1,0 +1,544 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+import net.imagej.table.Column;
+import net.imagej.table.GenericTable;
+
+import ij.measure.ResultsTable;
+
+/**
+ * Wraps a {@link ij.measure.ResultsTable} as a {@link GenericTable}.
+ *
+ * @author Alison Walter
+ */
+public class ResultsTableWrapper implements GenericTable {
+
+	private final ij.measure.ResultsTable table;
+
+	public ResultsTableWrapper(final ij.measure.ResultsTable table) {
+		this.table = table;
+	}
+
+	@Override
+	public int getColumnCount() {
+		return table.getLastColumn() + 1;
+	}
+
+	@Override
+	public void setColumnCount(final int colCount) {
+		throw new UnsupportedOperationException("setColumnCount(int)");
+	}
+
+	@Override
+	public Column<? extends Object> get(final String colHeader) {
+		return new ResultsTableColumnWrapper(table, table.getColumnIndex(
+			colHeader));
+	}
+
+	@Override
+	public Column<? extends Object> appendColumn() {
+		// Determine if empty cells are NaN or 0
+		double fill = 0;
+		try {
+			final Field f = ij.measure.ResultsTable.class.getDeclaredField(
+				"NaNEmptyCells");
+			f.setAccessible(true);
+			final boolean nan = (boolean) f.get(table);
+			fill = nan ? Double.NaN : 0;
+		}
+		catch (final Exception exc) {
+			// Keep as zero
+		}
+		// addValue does not increment the counter (row count) and sets the heading
+		// to "---"
+		table.addValue(table.getLastColumn() + 1, fill);
+		return get(table.getLastColumn());
+	}
+
+	@Override
+	public Column<? extends Object> appendColumn(final String header) {
+		final Column<?> c = appendColumn();
+		c.setHeader(header);
+		return c;
+	}
+
+	@Override
+	public List<Column<? extends Object>> appendColumns(final int count) {
+		final List<Column<?>> l = new ArrayList<>(count);
+		for (int i = 0; i < count; i++) {
+			l.add(appendColumn());
+		}
+		return l;
+	}
+
+	@Override
+	public List<Column<? extends Object>> appendColumns(final String... headers) {
+		final List<Column<?>> l = new ArrayList<>(headers.length);
+		for (int i = 0; i < headers.length; i++) {
+			l.add(appendColumn(headers[i]));
+		}
+		return l;
+	}
+
+	@Override
+	public Column<? extends Object> insertColumn(final int col) {
+		throw new IllegalArgumentException("insertColumn(int)");
+	}
+
+	@Override
+	public Column<? extends Object> insertColumn(final int col,
+		final String header)
+	{
+		throw new IllegalArgumentException("insertColumn(int, String)");
+	}
+
+	@Override
+	public List<Column<? extends Object>> insertColumns(final int col,
+		final int count)
+	{
+		throw new IllegalArgumentException("insertColumns(int, int)");
+	}
+
+	@Override
+	public List<Column<? extends Object>> insertColumns(final int col,
+		final String... headers)
+	{
+		throw new IllegalArgumentException("insertColumns(int, String...)");
+	}
+
+	@Override
+	public Column<? extends Object> removeColumn(final int col) {
+		throw new IllegalArgumentException("removeColumn(int)");
+	}
+
+	@Override
+	public Column<? extends Object> removeColumn(final String header) {
+		throw new IllegalArgumentException("removeColumn(String)");
+	}
+
+	@Override
+	public List<Column<? extends Object>> removeColumns(final int col,
+		final int count)
+	{
+		throw new IllegalArgumentException("removeColumns(int, int)");
+	}
+
+	@Override
+	public List<Column<? extends Object>> removeColumns(final String... headers) {
+		throw new IllegalArgumentException("removeColumns(String...)");
+	}
+
+	@Override
+	public int getRowCount() {
+		return table.size();
+	}
+
+	@Override
+	public void setRowCount(final int rowCount) {
+		throw new IllegalArgumentException("setRowCount(int)");
+	}
+
+	@Override
+	public void appendRow() {
+		// Determine if empty cells are NaN or 0
+		double fill = 0;
+		try {
+			final Field f = ij.measure.ResultsTable.class.getDeclaredField(
+				"NaNEmptyCells");
+			f.setAccessible(true);
+			final boolean nan = (boolean) f.get(table);
+			fill = nan ? Double.NaN : 0;
+		}
+		catch (final Exception exc) {
+			// Keep as zero
+		}
+
+		for (int i = 0; i <= table.getLastColumn(); i++) {
+			// setValue increments the column whereas addValue does not
+			table.setValue(i, table.size(), fill);
+		}
+	}
+
+	@Override
+	public void appendRow(final String header) {
+		appendRow(); // incremented row count
+		table.setLabel(header, table.size() - 1);
+	}
+
+	@Override
+	public void appendRows(final int count) {
+		for (int i = 0; i < count; i++) {
+			appendRow();
+		}
+	}
+
+	@Override
+	public void appendRows(final String... headers) {
+		for (int i = 0; i < headers.length; i++) {
+			appendRow(headers[i]);
+		}
+	}
+
+	@Override
+	public void insertRow(final int row) {
+		throw new UnsupportedOperationException("insertRow(int)");
+	}
+
+	@Override
+	public void insertRow(final int row, final String header) {
+		throw new UnsupportedOperationException("insertRow(int, String)");
+	}
+
+	@Override
+	public void insertRows(final int row, final int count) {
+		throw new UnsupportedOperationException("insertRows(int, int)");
+	}
+
+	@Override
+	public void insertRows(final int row, final String... headers) {
+		throw new UnsupportedOperationException("insertRows(int, String...)");
+	}
+
+	@Override
+	public void removeRow(final int row) {
+		table.deleteRow(row);
+	}
+
+	@Override
+	public void removeRow(final String header) {
+		for (int i = 0; i < table.size(); i++) {
+			if (table.getLabel(i).equals(header)) {
+				table.deleteRow(i);
+				break;
+			}
+		}
+	}
+
+	@Override
+	public void removeRows(final int row, final int count) {
+		for (int i = 0; i < count; i++) {
+			table.deleteRow(i + row);
+		}
+	}
+
+	@Override
+	public void removeRows(final String... headers) {
+		for (int i = 0; i < headers.length; i++) {
+			removeRow(headers[i]);
+		}
+	}
+
+	@Override
+	public void setDimensions(final int colCount, final int rowCount) {
+		throw new UnsupportedOperationException("setDimensions(int, int)");
+	}
+
+	@Override
+	public String getColumnHeader(final int col) {
+		return table.getColumnHeading(col);
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public void setColumnHeader(final int col, final String header) {
+		table.setHeading(col, header);
+	}
+
+	@Override
+	public int getColumnIndex(final String header) {
+		return table.getColumnIndex(header);
+	}
+
+	@Override
+	public String getRowHeader(final int row) {
+		return table.getLabel(row);
+	}
+
+	@Override
+	public void setRowHeader(final int row, final String header) {
+		table.setLabel(header, row);
+	}
+
+	@Override
+	public int getRowIndex(final String header) {
+		for (int i = 0; i < table.size(); i++) {
+			if (table.getLabel(i).equals(header)) return i;
+		}
+		return -1;
+	}
+
+	/**
+	 * Sets the value at the given row column. If the passed value is a
+	 * {@code Number} it will be stored as a {@code double}.
+	 */
+	@Override
+	public void set(final int col, final int row, final Object value) {
+		if (value instanceof String) table.setValue(col, row, (String) value);
+		else if (value instanceof Number) table.setValue(col, row, ((Number) value)
+			.doubleValue());
+	}
+
+	/**
+	 * Sets the value at the given row column. If the passed value is a
+	 * {@code Number} it will be stored as a {@code double}.
+	 */
+	@Override
+	public void set(final String colHeader, final int row, final Object value) {
+		if (value instanceof String) table.setValue(colHeader, row, (String) value);
+		else if (value instanceof Number) table.setValue(colHeader, row,
+			((Number) value).doubleValue());
+	}
+
+	@Override
+	public Object get(final int col, final int row) {
+		if (checkString(row, col)) return table.getStringValue(col, row);
+		return table.getValueAsDouble(col, row);
+	}
+
+	@Override
+	public Object get(final String colHeader, final int row) {
+		if (checkString(row, table.getColumnIndex(colHeader))) return table
+			.getStringValue(colHeader, row);
+		return table.getValueAsDouble(table.getColumnIndex(colHeader), row);
+	}
+
+	@Override
+	public int size() {
+		return table.getLastColumn() + 1;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return table.getCounter() == 0 && table.getLastColumn() == 0;
+	}
+
+	@Override
+	public boolean contains(final Object column) {
+		throw new UnsupportedOperationException("contains(Object)");
+	}
+
+	@Override
+	public Iterator<Column<? extends Object>> iterator() {
+		throw new UnsupportedOperationException("iterator()");
+	}
+
+	@Override
+	public Object[] toArray() {
+		final Object[] o = new Object[table.getLastColumn() + 1];
+		for (int i = 0; i <= table.getLastColumn(); i++) {
+			o[i] = new ResultsTableColumnWrapper(table, i);
+		}
+		return o;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <A> A[] toArray(final A[] a) {
+		final A[] copy = a.length < table.getLastColumn() + 1
+			? (A[]) java.lang.reflect.Array.newInstance(a.getClass()
+				.getComponentType(), table.getLastColumn() + 1) : a;
+
+		for (int i = 0; i < table.getLastColumn() + 1; i++) {
+			copy[i] = (A) new ResultsTableColumnWrapper(table, i);
+		}
+		if (copy.length > table.getLastColumn() + 1) copy[table.getLastColumn() +
+			1] = null;
+
+		return copy;
+	}
+
+	@Override
+	public boolean add(final Column<? extends Object> column) {
+		final int colIndex = table.getLastColumn() + 1;
+		for (int i = 0; i < column.size(); i++) {
+			if (column.get(i) instanceof Number) table.setValue(colIndex, i,
+				((Number) column.get(i)).doubleValue());
+			else if (column.get(i) != null) table.setValue(colIndex, i, column.get(i).toString());
+			else return false;
+		}
+		return true;
+	}
+
+	@Override
+	public boolean remove(final Object column) {
+		throw new UnsupportedOperationException("remove(Object)");
+	}
+
+	@Override
+	public boolean containsAll(final Collection<?> c) {
+		throw new UnsupportedOperationException("containsAll(Collection)");
+	}
+
+	@Override
+	public boolean addAll(
+		final Collection<? extends Column<? extends Object>> c)
+	{
+		boolean b = false;
+		for (final Column<?> col : c) {
+			b = b || add(col);
+		}
+		return b;
+	}
+
+	@Override
+	public boolean addAll(final int col,
+		final Collection<? extends Column<? extends Object>> c)
+	{
+		throw new UnsupportedOperationException("addAll(int, Collection)");
+	}
+
+	@Override
+	public boolean removeAll(final Collection<?> c) {
+		throw new UnsupportedOperationException("removeAll(Collection)");
+	}
+
+	@Override
+	public boolean retainAll(final Collection<?> c) {
+		throw new UnsupportedOperationException("retainAll(Collection)");
+	}
+
+	@Override
+	public void clear() {
+		table.reset();
+	}
+
+	@Override
+	public Column<? extends Object> get(final int col) {
+		return new ResultsTableColumnWrapper(table, col);
+	}
+
+	/**
+	 * Returns null, since the previous column needs to be overwritten with the
+	 * new column.
+	 */
+	@Override
+	public Column<? extends Object> set(final int col,
+		final Column<? extends Object> column)
+	{
+		final Column<Object> w = new ResultsTableColumnWrapper(table, col);
+		for (int i = 0; i < column.size(); i++) {
+			w.set(i, column.get(i));
+		}
+		return null;
+	}
+
+	@Override
+	public void add(final int col, final Column<? extends Object> column) {
+		throw new UnsupportedOperationException("add(int, Column)");
+	}
+
+	@Override
+	public Column<? extends Object> remove(final int col) {
+		throw new UnsupportedOperationException("remove(int)");
+	}
+
+	@Override
+	public int indexOf(final Object column) {
+		throw new UnsupportedOperationException("indexOf(Object)");
+	}
+
+	@Override
+	public int lastIndexOf(final Object column) {
+		throw new UnsupportedOperationException("lastIndexOf(Object)");
+	}
+
+	@Override
+	public ListIterator<Column<? extends Object>> listIterator() {
+		throw new UnsupportedOperationException("listIterator()");
+	}
+
+	@Override
+	public ListIterator<Column<? extends Object>> listIterator(final int col) {
+		throw new UnsupportedOperationException("listIterator(int)");
+	}
+
+	@Override
+	public List<Column<? extends Object>> subList(final int fromCol,
+		final int toCol)
+	{
+		final List<Column<?>> l = new ArrayList<>(toCol - fromCol);
+		for (int i = fromCol; i < toCol; i++) {
+			l.add(new ResultsTableColumnWrapper(table, i));
+		}
+		return l;
+	}
+
+// -- Helper methods --
+
+	/**
+	 * Checks if the value at the given position is a String.
+	 *
+	 * @return true if the value at the given location is a String, otherwise
+	 *         false
+	 */
+	private boolean checkString(final int row, final int col) {
+		final double d = table.getValueAsDouble(col, row);
+		final String s = table.getStringValue(col, row);
+
+		// convert d to a string, as ResultsTable would
+		String c = "";
+		try {
+			final Field f = ij.measure.ResultsTable.class.getDeclaredField(
+				"decimalPlaces");
+			f.setAccessible(true);
+			final short[] dec = (short[]) f.get(table);
+			final short places = dec[col];
+			if (places == Short.MIN_VALUE) {
+				final Method m = table.getClass().getDeclaredMethod("n", double.class);
+				m.setAccessible(true);
+				c = (String) m.invoke(table, d);
+			}
+			else {
+				c = ResultsTable.d2s(d, dec[col]);
+			}
+		}
+		catch (final Exception exc) {
+			// if can't get the decimal places or n(...), call d2s with AUTO_FORMAT
+			c = ResultsTable.d2s(d, ij.measure.ResultsTable.AUTO_FORMAT);
+		}
+
+		// Special case for NaN
+		if (((Double) d).isNaN() && (s == "" || s == null)) return false;
+
+		return !s.equals(c);
+	}
+
+}

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -97,6 +97,7 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.convert.ImagePlusToImageDisplayConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ImageTitleToImagePlusConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableColumnWrapper.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.ResultsTableToGenericTableConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.StringToImagePlusConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.display.AbstractImagePlusDisplayViewer.class.getName()) ||

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -96,6 +96,8 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.convert.ImagePlusToDatasetConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ImagePlusToImageDisplayConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ImageTitleToImagePlusConverter.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.ResultsTableColumnWrapper.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.ResultsTableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.StringToImagePlusConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.display.AbstractImagePlusDisplayViewer.class.getName()) ||
 					className.startsWith(net.imagej.legacy.display.LegacyImageDisplayService.class.getName()) ||

--- a/src/test/java/net/imagej/legacy/convert/ResultsTableConversionTest.java
+++ b/src/test/java/net/imagej/legacy/convert/ResultsTableConversionTest.java
@@ -1,0 +1,238 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import net.imagej.patcher.LegacyInjector;
+import net.imagej.table.Column;
+import net.imagej.table.GenericTable;
+import net.imagej.table.Table;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.convert.ConvertService;
+
+import ij.measure.ResultsTable;
+
+/**
+ * Tests table converters and wrappers.
+ *
+ * @author Alison Walter
+ */
+public class ResultsTableConversionTest {
+
+	static {
+		LegacyInjector.preinit();
+	}
+
+	private ResultsTable table;
+
+	private final String[] headings = { "col 1", "col2", "col-3", "col_4",
+		"col 5" };
+
+	private final String[] rowLabels = { "label1", null, null, null, "label5" };
+
+	private final double[][] values = { { 100, -30, 0.125, 3456, -0.5 }, { 0, 0,
+		11, 113, -93 }, { 0, 0, 0, 0, 0 }, { 0.0009765625, 85.015625, 0,
+			-2.00048828125, 101.5 }, { 0, -10, 0.125, 8, 0 } };
+
+	private final String[][] stringValues = { { null, null, null, null, null }, {
+		"hello", null, null, null, null }, { "a", "b", "g", "q", "w" }, { null,
+			null, "middle", null, null }, { null, null, null, null, "see ya!" } };
+
+	private Context context;
+
+	private ConvertService convertService;
+
+	@Before
+	public void setup() {
+		table = new ResultsTable();
+
+		for (int i = 0; i < headings.length; i++) {
+			for (int j = 0; j < rowLabels.length; j++) {
+				if (stringValues[i][j] != null) table.setValue(headings[i], j,
+					stringValues[i][j]);
+				else table.setValue(headings[i], j, values[i][j]);
+				if (i == 0 && rowLabels[j] != null) table.setLabel(rowLabels[j], j);
+			}
+		}
+	}
+
+	@Test
+	public void testColumnWrapperDoubleGet() {
+		final Column<Object> c = new ResultsTableColumnWrapper(table, 0);
+
+		// Test get
+		for (int i = 0; i < table.size(); i++) {
+			final Object o = c.get(i);
+			assertTrue(o instanceof Double);
+			assertEquals((Double) o, values[0][i], 0);
+		}
+	}
+
+	@Test
+	public void testColumnWrapperStringGet() {
+		final Column<Object> c = new ResultsTableColumnWrapper(table, 2);
+
+		for (int i = 0; i < table.size(); i++) {
+			final Object o = c.get(i);
+			assertTrue(o instanceof String);
+			assertEquals(o, stringValues[2][i]);
+		}
+	}
+
+	@Test
+	public void testColumnWrapperMixedGet() {
+		final Column<Object> c = new ResultsTableColumnWrapper(table, 3);
+
+		for (int i = 0; i < table.size(); i++) {
+			final Object o = c.get(i);
+			if (i == 2) {
+				assertTrue(o instanceof String);
+				assertEquals(o, stringValues[3][i]);
+			}
+			else {
+				assertTrue(o instanceof Double);
+				assertEquals((Double) o, values[3][i], 0);
+			}
+		}
+	}
+
+	@Test
+	public void testColumnWrapper() {
+		final Column<Object> c = new ResultsTableColumnWrapper(table, 4);
+
+		// Test set heading
+		assertEquals(c.getHeader(), "col 5");
+		c.setHeader("header");
+		assertEquals(c.getHeader(), "header");
+
+		// Test indexOf
+		assertTrue(c.indexOf(8) == 3);
+		assertTrue(c.indexOf("see ya!") == 4);
+
+		// Test add value
+		c.add("I'm new!");
+		assertEquals("I'm new!", c.get(5));
+		c.add(17);
+		assertEquals(17, (Double) c.get(6), 0);
+
+		assertEquals(7, c.size());
+
+		// Test lastIndexOf
+		c.add(8);
+		assertEquals(7, c.lastIndexOf(8));
+		assertEquals(3, c.indexOf(8));
+
+		c.add("I'm new!");
+		assertEquals(8, c.lastIndexOf("I'm new!"));
+		assertEquals(5, c.indexOf("I'm new!"));
+
+		assertEquals(9, c.size());
+
+		// Test set value
+		c.set(3, "buh bye");
+		assertEquals("buh bye", c.get(3));
+		c.set(5, 125);
+		assertEquals(125, (Double) c.get(5), 0);
+
+		assertEquals(9, c.size());
+
+		// Test clear
+		c.clear();
+		for (int i = 0; i < c.size(); i++)
+			assertEquals(0, (Double) c.get(i), 0);
+
+		table.setNaNEmptyCells(true);
+		c.clear();
+		for (int i = 0; i < c.size(); i++)
+			assertTrue(((Double) c.get(i)).isNaN());
+	}
+
+	@Test
+	public void testResultsTableWrapper() {
+		final Table<Column<? extends Object>, Object> t = new ResultsTableWrapper(
+			table);
+
+		// check table dimensions
+		assertEquals(5, t.getColumnCount());
+		assertEquals(5, t.getRowCount());
+
+		// check values
+		for (int i = 0; i < t.getColumnCount(); i++) {
+			assertEquals(headings[i], t.getColumnHeader(i));
+			for (int j = 0; j < t.getRowCount(); j++) {
+				if (stringValues[i][j] != null) assertEquals(stringValues[i][j], t.get(
+					i, j));
+				else assertEquals(values[i][j], (Double) t.get(i, j), 0);
+			}
+		}
+
+		// Test set value
+		t.set(0, 0, "Hey there");
+		assertEquals("Hey there", t.get(0, 0));
+		t.set(0, 1, 25);
+		assertEquals(25, (Double) t.get(0, 1), 0);
+
+		// Test remove row
+		t.removeRow(2);
+		for (int i = 0; i < t.getColumnCount(); i++) {
+			if (stringValues[i][3] != null) assertEquals(stringValues[i][3], t.get(i,
+				2));
+			else assertEquals(values[i][3], (Double) t.get(i, 2), 0);
+		}
+	}
+
+	@Test
+	public void testConvert() {
+		context = new Context();
+		convertService = context.service(ConvertService.class);
+
+		final GenericTable t = convertService.convert(table, GenericTable.class);
+
+		// check values
+		for (int i = 0; i < t.getColumnCount(); i++) {
+			assertEquals(headings[i], t.getColumnHeader(i));
+			for (int j = 0; j < t.getRowCount(); j++) {
+				if (stringValues[i][j] != null) assertEquals(table.getStringValue(i, j),
+					t.get(i, j));
+				else assertEquals(table.getValueAsDouble(i, j), (Double) t.get(i, j),
+					0);
+			}
+		}
+
+		context.dispose();
+	}
+}


### PR DESCRIPTION
Hello!

These commits add a converter for going from an ImageJ 1.x `ResultsTable` to a `GenericTable`, and add tests for this converter. All commits build with passing tests.

Please let me know if you have any questions/concerns regarding these changes.

Thanks, 

Alison