### PR TITLE
Add "Process Open Images" IJ1 macro template

### DIFF
--- a/src/main/resources/script_templates/ImageJ_1.x/Examples/Process_Open_Images.ijm
+++ b/src/main/resources/script_templates/ImageJ_1.x/Examples/Process_Open_Images.ijm
@@ -1,0 +1,36 @@
+// @File(label = "Output directory", style = "directory") output
+// @String(label = "Title contains") pattern
+
+/*
+ * Macro template to process multiple open images
+ */
+processOpenImages();
+
+/*
+ * Processes all open images. If an image matches the provided title
+ * pattern, processImage() is executed.
+ */
+function processOpenImages() {
+	n = nImages;
+	setBatchMode(true);
+	for (i=1; i<=n; i++) {
+		selectImage(i);
+		imageTitle = getTitle();
+		imageId = getImageID();
+		if (matches(imageTitle, "(.*)"+pattern+"(.*)"))
+			processImage(imageTitle, imageId, output);
+	}
+	setBatchMode(false);
+}
+
+/*
+ * Processes the currently active image. Use imageId parameter
+ * to re-select the input image during processing.
+ */
+function processImage(imageTitle, imageId, output) {
+	// Do the processing here by adding your own code.
+	// Leave the print statements until things work, then remove them.
+	print("Processing: " + imageTitle);
+	pathToOutputFile = output + File.separator + imageTitle + ".png";
+	print("Saving to: " + pathToOutputFile);
+}


### PR DESCRIPTION
The macro is modeled after the `Process_Folder.*` templates but processes open images instead of images in a folder.