### PR TITLE
Batch scripts

### DIFF
--- a/src/main/resources/script_templates/ImageJ_1.x/Examples/Process_Folder.groovy
+++ b/src/main/resources/script_templates/ImageJ_1.x/Examples/Process_Folder.groovy
@@ -1,0 +1,39 @@
+#@ File    (label = "Input directory", style = "directory") srcFile
+#@ File    (label = "Output directory", style = "directory") dstFile
+#@ String  (label = "File extension", value=".tif") ext
+#@ String  (label = "File name contains", value = "") containString
+#@ Boolean (label = "Keep directory structure when saving", value = true) keepDirectories
+
+import ij.IJ
+
+def main() {
+	srcFile.eachFileRecurse {
+		name = it.getName()
+		if (name.endsWith(ext) && name.contains(containString)) {
+			process(it, srcFile, dstFile, keepDirectories)
+		}
+	}
+}
+
+def process(file, src, dst, keep) {
+	println "Processing $file"
+
+	// Opening the image
+	imp = IJ.openImage(file.getAbsolutePath())
+
+	// Put your processing steps here
+
+	// Saving the result
+	relativePath = keep ?
+			src.toPath().relativize(file.getParentFile().toPath()).toString()
+			: "" // no relative path
+	saveDir = new File(dst.toPath().toString(), relativePath)
+	if (!saveDir.exists()) saveDir.mkdirs()
+	saveFile = new File(saveDir, file.getName()) // customize name if needed
+	IJ.saveAs(imp, "Tiff", saveFile.getAbsolutePath());
+
+	// Clean up
+	imp.close()
+}
+
+main()

--- a/src/main/resources/script_templates/ImageJ_1.x/Examples/Process_Folder.py
+++ b/src/main/resources/script_templates/ImageJ_1.x/Examples/Process_Folder.py
@@ -1,8 +1,8 @@
-# @File(label = "Input directory", style = "directory") srcFile
-# @File(label = "Output directory", style = "directory") dstFile
-# @String(label = "File extension", value=".tif") ext
-# @String(label = "File name contains", value = "") containString
-# @boolean(label = "Keep directory structure when saving", value = true) keepDirectories
+#@ File    (label = "Input directory", style = "directory") srcFile
+#@ File    (label = "Output directory", style = "directory") dstFile
+#@ String  (label = "File extension", value=".tif") ext
+#@ String  (label = "File name contains", value = "") containString
+#@ boolean (label = "Keep directory structure when saving", value = true) keepDirectories
 
 # See also Process_Folder.ijm for a version of this code
 # in the ImageJ 1.x macro language.


### PR DESCRIPTION
This PR adds a Groovy example for batch processing, and adjusts the script parameter syntax in the Python example to the new language-agnostic `#@` style.

(Both scripts were tested on multiply nested folder structures, both with and without the 'keepDirectories' option.)