### PR TITLE
Fix duplicate entries in image selections

### DIFF
--- a/src/main/java/net/imagej/legacy/convert/ImageDisplayToImagePlusConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/ImageDisplayToImagePlusConverter.java
@@ -35,7 +35,9 @@ import ij.ImagePlus;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.List;
 
+import net.imagej.DatasetService;
 import net.imagej.display.ImageDisplay;
 import net.imagej.legacy.LegacyService;
 
@@ -64,6 +66,9 @@ public class ImageDisplayToImagePlusConverter extends
 
 	@Parameter(required = false)
 	private ObjectService objectService;
+
+	@Parameter(required = false)
+	private DatasetService datasetService;
 
 	// -- Converter methods --
 
@@ -106,7 +111,12 @@ public class ImageDisplayToImagePlusConverter extends
 	@Override
 	public void populateInputCandidates(final Collection<Object> objects) {
 		if (objectService == null) return;
-		objects.addAll(objectService.getObjects(ImageDisplay.class));
+		List<ImageDisplay> imageDisplays = objectService.getObjects(ImageDisplay.class);
+		for (ImageDisplay imageDisplay : imageDisplays) {
+			if (datasetService.getDatasets(imageDisplay).isEmpty()) {
+				objects.add(imageDisplay);
+			}
+		}
 	}
 
 	@Override

--- a/src/main/java/net/imagej/legacy/convert/ImageTitleToImagePlusConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/ImageTitleToImagePlusConverter.java
@@ -36,9 +36,14 @@ import ij.WindowManager;
 
 import java.util.Collection;
 
+import net.imagej.DatasetService;
+import net.imagej.display.ImageDisplay;
+import net.imagej.legacy.LegacyService;
+
 import org.scijava.convert.AbstractConverter;
 import org.scijava.convert.ConvertService;
 import org.scijava.convert.Converter;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.widget.ObjectWidget;
 import org.scijava.widget.WidgetModel;
@@ -66,6 +71,12 @@ public class ImageTitleToImagePlusConverter extends
 	AbstractConverter<ImageTitleToImagePlusConverter.ImageTitle, ImagePlus>
 {
 
+	@Parameter(required = false)
+	private DatasetService datasetService;
+
+	@Parameter(required = false)
+	private LegacyService legacyService;
+
 	// -- Converter methods --
 
 	@Override
@@ -80,7 +91,14 @@ public class ImageTitleToImagePlusConverter extends
 		if (imageIDs == null) return;
 		for (final int imageID : imageIDs) {
 			final ImagePlus imp = WindowManager.getImage(imageID);
-			if (imp != null) objects.add(new ImageTitle(imp));
+			if (imp != null) {
+				ImageTitle imageTitle = new ImageTitle(imp);
+				// Prefer a Dataset if it is available (don't add to objects)
+				ImageDisplay imageDisplay = legacyService.getImageMap().lookupDisplay(imp);
+				if(datasetService.getDatasets(imageDisplay).isEmpty()) {
+					objects.add(imageTitle);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously, image selections (e.g. in a Swing UI) would show three entries in a dropdown for each image opened as a `Dataset`. The issue was that multiple `Converter`s would add convertible inputs to the set of compatible inputs without checking if another converter has added a
different representation of the same data (e.g. `ImageTitle`, `ImageDisplay`, `Dataset`).

This commit changes the implementation in `ImageTitleToImagePlusConverter` to check if a `Dataset` is available, i.e. it prefers `Dataset`s. Similar changes check for an available `Dataset` in the `ImageDisplayToImagePlusConverter` to prefer that.