### PR TITLE
Support ij.gui.Overlay input parameters

### DIFF
--- a/src/main/java/net/imagej/legacy/IJ1Helper.java
+++ b/src/main/java/net/imagej/legacy/IJ1Helper.java
@@ -40,6 +40,7 @@ import ij.Menus;
 import ij.Prefs;
 import ij.WindowManager;
 import ij.gui.ImageWindow;
+import ij.gui.Overlay;
 import ij.gui.Toolbar;
 import ij.io.DirectoryChooser;
 import ij.io.OpenDialog;
@@ -254,6 +255,7 @@ public class IJ1Helper extends AbstractContextual {
 	/** Add name aliases for ImageJ1 classes to the ScriptService. */
 	public void addAliases(final ScriptService scriptService) {
 		scriptService.addAlias(ImagePlus.class);
+		scriptService.addAlias("IJ1Overlay", Overlay.class);
 		scriptService.addAlias(ResultsTable.class);
 		scriptService.addAlias(RoiManager.class);
 	}

--- a/src/main/java/net/imagej/legacy/plugin/OverlayPreprocessor.java
+++ b/src/main/java/net/imagej/legacy/plugin/OverlayPreprocessor.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.plugin;
+
+import ij.ImagePlus;
+import ij.WindowManager;
+import ij.gui.Overlay;
+
+import org.scijava.Priority;
+import org.scijava.module.Module;
+import org.scijava.module.process.AbstractSingleInputPreprocessor;
+import org.scijava.module.process.PreprocessorPlugin;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Injects the {@link Overlay} of the current {@link ImagePlus} when a single
+ * {@link Overlay} is declared as a parameter.
+ * 
+ * @author Jan Eglinger
+ */
+@Plugin(type = PreprocessorPlugin.class, priority = Priority.VERY_HIGH)
+public class OverlayPreprocessor extends AbstractSingleInputPreprocessor {
+
+	// -- ModuleProcessor methods --
+
+	@Override
+	public void process(final Module module) {
+		// add Overlay from imp to single Overlay input
+		final String overlayInput = getSingleInput(module, Overlay.class);
+		if (overlayInput != null) {
+			// TODO: Change this to a LegacyService API call?
+			final ImagePlus imp = WindowManager.getCurrentImage();
+			if (imp == null)
+				return;
+			Overlay ovl = imp.getOverlay();
+			if (ovl == null)
+				return;
+			module.setInput(overlayInput, ovl);
+			module.resolveInput(overlayInput);
+		}
+	}
+}

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -165,6 +165,7 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.plugin.DefaultLegacyOpener.class.getName()) ||
 					className.startsWith(net.imagej.legacy.plugin.IJ1MacroEngine.class.getName()) ||
 					className.startsWith(net.imagej.legacy.plugin.LegacyInitializer.class.getName()) ||
+					className.startsWith(net.imagej.legacy.plugin.OverlayPreprocessor.class.getName()) ||
 					className.startsWith(net.imagej.legacy.plugin.ResultsTablePreprocessor.class.getName()) ||
 					className.startsWith(net.imagej.legacy.plugin.RoiManagerPreprocessor.class.getName()) ||
 					className.startsWith(net.imagej.legacy.translate.AbstractDisplayCreator.class.getName()) ||


### PR DESCRIPTION
As an alias for `net.imagej.overlay.Overlay` [already existed](https://github.com/imagej/imagej-common/blob/dfb719196e516d19914f0ef550447d238ecf9732/src/main/java/net/imagej/display/DefaultImageDisplayService.java#L162), this introduces a script alias "IJ1Overlay" for `ij.gui.Overlay`.

This basically saves a line of code in scripts. Instead of:

```groovy
#@ ImagePlus imp
ovl = imp.getOverlay()
```

you can write:

```groovy
#@ IJ1Overlay ovl
```

If the community agrees that supporting `ij.gui.Overlay` is useful, I can add a test to this PR testing its correct behavior.
