### PR TITLE
LegacyImageMap: do harmonization on display update

### DIFF
--- a/src/main/java/net/imagej/legacy/LegacyImageMap.java
+++ b/src/main/java/net/imagej/legacy/LegacyImageMap.java
@@ -511,7 +511,12 @@ public class LegacyImageMap extends AbstractContextual {
 		final Display<?> display = event.getDisplay();
 		if (display instanceof ImageDisplay) {
 			final ImagePlus mappedImagePlus = lookupImagePlus((ImageDisplay) event.getDisplay());
-			if (mappedImagePlus != null) mappedImagePlus.updateAndDraw();
+			if (mappedImagePlus != null) {
+				final Harmonizer harmonizer =
+						new Harmonizer(legacyService.getContext(), imageTranslator);
+				harmonizer.updateLegacyImage((ImageDisplay) display, mappedImagePlus);
+				mappedImagePlus.updateAndDraw();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Legacy `ImagePlus`es are—in some circumstances—created by copying (not referencing) the underlying pixels of a `Dataset`. Hence, a change in a `Dataset` is not propagated properly to the `ImagePlus` if no harmonization between the two is happening. This PR adds harmonization logic when a `DisplayUpdatedEvent` is triggered. 