### PR TITLE
fixed typo in rotate/translate line ROI

### DIFF
--- a/src/main/resources/script_templates/ImageJ_1.x/Examples/Manipulate_LineROI.ijm
+++ b/src/main/resources/script_templates/ImageJ_1.x/Examples/Manipulate_LineROI.ijm
@@ -56,7 +56,7 @@ function rotatePoint(theta,x,y,h,w){
 	y2 = (x1*sin(theta))+(y1*cos(theta));
 	// Translate back to imageJ coordinates
 	x2 = x2 + (w/2); 
-	y2 = (w/2)-y2;
+	y2 = (h/2)-y2;
 	point = newArray(x2,y2);
 	return point;
 }


### PR DESCRIPTION
Missed a typo that doesn't affect rotation using square images, but impacts rotation in rectangular images.