### PR TITLE
Attach ROIs/Tables when converting ImagePlus/Dataset

### DIFF
--- a/src/main/java/net/imagej/legacy/convert/OverlayToROITreeConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/OverlayToROITreeConverter.java
@@ -1,0 +1,89 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imagej.legacy.convert;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.roi.DefaultROITree;
+import net.imagej.roi.ROITree;
+import net.imglib2.roi.MaskPredicate;
+
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.ConvertService;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import ij.gui.Overlay;
+
+/**
+ * Converts an {@link Overlay} to a {@link ROITree}.
+ *
+ * @author Alison Walter
+ */
+@Plugin(type = Converter.class)
+public class OverlayToROITreeConverter extends
+	AbstractConverter<Overlay, ROITree>
+{
+
+	@Parameter
+	private ConvertService convertService;
+
+	@Override
+	public Class<Overlay> getInputType() {
+		return Overlay.class;
+	}
+
+	@Override
+	public Class<ROITree> getOutputType() {
+		return ROITree.class;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T convert(Object src, Class<T> dest) {
+		if (!getInputType().isInstance(src)) throw new IllegalArgumentException(
+			"Unexpected source type: " + src.getClass());
+		if (!getOutputType().isAssignableFrom(dest))
+			throw new IllegalArgumentException("Unexpected output class: " + dest);
+
+		final Overlay o = (Overlay) src;
+		final List<MaskPredicate<?>> converted = new ArrayList<>();
+		for (int i = 0; i < o.size(); i++)
+			converted.add(convertService.convert(o.get(i), MaskPredicate.class));
+
+		final ROITree rois = new DefaultROITree();
+		rois.addROIs(converted);
+		return (T) rois;
+	}
+
+}

--- a/src/main/java/net/imagej/legacy/convert/ROITreeToOverlayConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/ROITreeToOverlayConverter.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import net.imagej.roi.ROITree;
+import net.imglib2.roi.MaskPredicate;
+
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.ConvertService;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.util.TreeNode;
+
+import ij.gui.Overlay;
+
+/**
+ * Converts a {@link ROITree} to an {@link Overlay}.
+ *
+ * @author Alison Walter
+ */
+@Plugin(type = Converter.class)
+public class ROITreeToOverlayConverter extends
+	AbstractConverter<ROITree, Overlay>
+{
+
+	@Parameter
+	private ConvertService convertService;
+
+	@Override
+	public Class<ROITree> getInputType() {
+		return ROITree.class;
+	}
+
+	@Override
+	public Class<Overlay> getOutputType() {
+		return Overlay.class;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T convert(final Object src, final Class<T> dest) {
+		if (!getInputType().isInstance(src)) throw new IllegalArgumentException(
+			"Unexpected source type: " + src.getClass());
+		if (!getOutputType().isAssignableFrom(dest))
+			throw new IllegalArgumentException("Unexpected output class: " + dest);
+
+		final ROITree rois = (ROITree) src;
+		final Overlay o = new Overlay();
+		addROIs(rois, o);
+		return (T) o;
+	}
+
+	private void addROIs(final TreeNode<?> rois, final Overlay overlay) {
+		if (rois.data() instanceof MaskPredicate) {
+			final ij.gui.Roi ijRoi = convertService.convert(rois.data(),
+				ij.gui.Roi.class);
+			overlay.add(ijRoi);
+		}
+		if (rois.children() == null || rois.children().isEmpty()) return;
+		for (final TreeNode<?> roi : rois.children())
+			addROIs(roi, overlay);
+	}
+
+}

--- a/src/main/java/net/imagej/legacy/convert/ResultsTableUnwrapper.java
+++ b/src/main/java/net/imagej/legacy/convert/ResultsTableUnwrapper.java
@@ -1,0 +1,69 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import org.scijava.Priority;
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Converts a {@link ResultsTableWrapper} to a {@link ij.measure.ResultsTable}
+ * via unwrapping.
+ *
+ * @author Alison Walter
+ */
+@Plugin(type = Converter.class, priority = Priority.VERY_HIGH)
+public class ResultsTableUnwrapper extends
+	AbstractConverter<ResultsTableWrapper, ij.measure.ResultsTable>
+{
+
+	@Override
+	public Class<ResultsTableWrapper> getInputType() {
+		return ResultsTableWrapper.class;
+	}
+
+	@Override
+	public Class<ij.measure.ResultsTable> getOutputType() {
+		return ij.measure.ResultsTable.class;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T convert(final Object src, final Class<T> dest) {
+		if (!getInputType().isInstance(src)) throw new IllegalArgumentException(src
+			.getClass() + " is not instance of input type: " + getInputType());
+
+		return (T) ((ResultsTableWrapper) src).getSource();
+	}
+
+}

--- a/src/main/java/net/imagej/legacy/convert/ResultsTableWrapper.java
+++ b/src/main/java/net/imagej/legacy/convert/ResultsTableWrapper.java
@@ -31,6 +31,8 @@
 
 package net.imagej.legacy.convert;
 
+import ij.measure.ResultsTable;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -41,8 +43,6 @@ import java.util.ListIterator;
 
 import net.imagej.table.Column;
 import net.imagej.table.GenericTable;
-
-import ij.measure.ResultsTable;
 
 /**
  * Wraps a {@link ij.measure.ResultsTable} as a {@link GenericTable}.
@@ -55,6 +55,10 @@ public class ResultsTableWrapper implements GenericTable {
 
 	public ResultsTableWrapper(final ij.measure.ResultsTable table) {
 		this.table = table;
+	}
+
+	public ij.measure.ResultsTable getSource() {
+		return table;
 	}
 
 	@Override

--- a/src/main/java/net/imagej/legacy/convert/TableListWrapper.java
+++ b/src/main/java/net/imagej/legacy/convert/TableListWrapper.java
@@ -1,0 +1,229 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+import net.imagej.table.Table;
+
+import org.scijava.convert.ConvertService;
+
+public class TableListWrapper implements List<ij.measure.ResultsTable> {
+
+	private List<Table<?, ?>> tables;
+	private final ConvertService convertService;
+	private List<ij.measure.ResultsTable> resultsTables;
+
+	public TableListWrapper(final List<Table<?, ?>> tables,
+		final ConvertService convertService)
+	{
+		this.tables = tables;
+		this.convertService = convertService;
+	}
+
+	/**
+	 * Returns the source {@code List<Table<?, ?>>}. This may be out of sync.
+	 *
+	 * @return The source {@code List<Table<?, ?>>}
+	 */
+	public List<Table<?, ?>> getSource() {
+		return tables;
+	}
+
+	/**
+	 * Synchronizes {@code this} and the source {@code List<Table<?, ?>>}.
+	 */
+	public void synchronize() {
+		if (resultsTables == null) return;
+		final List<Table<?, ?>> updated = new ArrayList<>();
+		for (final ij.measure.ResultsTable resultsTable : getResultsTables()) {
+			final Table<?, ?> table = convertService.convert(resultsTable,
+				Table.class);
+			updated.add(table);
+		}
+		tables = updated;
+	}
+
+	/**
+	 * Synchronizes and returns the source {@code List<Table<?, ?>>}.
+	 *
+	 * @return The synchronized source {@code List<Table<?, ?>>}
+	 */
+	public List<Table<?, ?>> getUpdatedSource() {
+		if (resultsTables == null) return tables;
+		synchronize();
+		return getSource();
+	}
+
+	@Override
+	public int size() {
+		return getResultsTables().size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return getResultsTables().isEmpty();
+	}
+
+	@Override
+	public boolean contains(final Object o) {
+		return getResultsTables().contains(o);
+	}
+
+	@Override
+	public Iterator<ij.measure.ResultsTable> iterator() {
+		return getResultsTables().iterator();
+	}
+
+	@Override
+	public Object[] toArray() {
+		return getResultsTables().toArray();
+	}
+
+	@Override
+	public <T> T[] toArray(final T[] a) {
+		return getResultsTables().toArray(a);
+	}
+
+	@Override
+	public boolean add(final ij.measure.ResultsTable e) {
+		return getResultsTables().add(e);
+	}
+
+	@Override
+	public boolean remove(final Object o) {
+		return getResultsTables().remove(o);
+	}
+
+	@Override
+	public boolean containsAll(final Collection<?> c) {
+		return getResultsTables().containsAll(c);
+	}
+
+	@Override
+	public boolean addAll(final Collection<? extends ij.measure.ResultsTable> c) {
+		return getResultsTables().addAll(c);
+	}
+
+	@Override
+	public boolean addAll(final int index,
+		final Collection<? extends ij.measure.ResultsTable> c)
+	{
+		return getResultsTables().addAll(index, c);
+	}
+
+	@Override
+	public boolean removeAll(final Collection<?> c) {
+		return getResultsTables().removeAll(c);
+	}
+
+	@Override
+	public boolean retainAll(final Collection<?> c) {
+		return getResultsTables().retainAll(c);
+	}
+
+	@Override
+	public void clear() {
+		getResultsTables().clear();
+	}
+
+	@Override
+	public ij.measure.ResultsTable get(final int index) {
+		return getResultsTables().get(index);
+	}
+
+	@Override
+	public ij.measure.ResultsTable set(final int index,
+		final ij.measure.ResultsTable element)
+	{
+		return getResultsTables().set(index, element);
+	}
+
+	@Override
+	public void add(final int index, final ij.measure.ResultsTable element) {
+		getResultsTables().add(index, element);
+	}
+
+	@Override
+	public ij.measure.ResultsTable remove(final int index) {
+		return getResultsTables().remove(index);
+	}
+
+	@Override
+	public int indexOf(final Object o) {
+		return getResultsTables().indexOf(o);
+	}
+
+	@Override
+	public int lastIndexOf(final Object o) {
+		return getResultsTables().lastIndexOf(o);
+	}
+
+	@Override
+	public ListIterator<ij.measure.ResultsTable> listIterator() {
+		return getResultsTables().listIterator();
+	}
+
+	@Override
+	public ListIterator<ij.measure.ResultsTable> listIterator(final int index) {
+		return getResultsTables().listIterator(index);
+	}
+
+	@Override
+	public List<ij.measure.ResultsTable> subList(final int fromIndex,
+		final int toIndex)
+	{
+		return getResultsTables().subList(fromIndex, toIndex);
+	}
+
+	// -- Helper methods --
+
+	private List<ij.measure.ResultsTable> getResultsTables() {
+		if (resultsTables == null) createResultsTableList();
+		return resultsTables;
+	}
+
+	private synchronized void createResultsTableList() {
+		if (resultsTables != null) return;
+		final List<ij.measure.ResultsTable> rts = new ArrayList<>();
+		for (final Table<?, ?> table : tables) {
+			final ij.measure.ResultsTable rt = convertService.convert(table,
+				ij.measure.ResultsTable.class);
+			rts.add(rt);
+		}
+		resultsTables = rts;
+	}
+}

--- a/src/main/java/net/imagej/legacy/convert/TableToResultsTableConverters.java
+++ b/src/main/java/net/imagej/legacy/convert/TableToResultsTableConverters.java
@@ -1,0 +1,225 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.imagej.table.ByteTable;
+import net.imagej.table.Column;
+import net.imagej.table.FloatTable;
+import net.imagej.table.GenericTable;
+import net.imagej.table.IntTable;
+import net.imagej.table.LongTable;
+import net.imagej.table.ResultsTable;
+import net.imagej.table.ShortTable;
+import net.imagej.table.Table;
+
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.ConvertService;
+import org.scijava.convert.Converter;
+import org.scijava.log.LogService;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Converters which convert {@link Table} to {@link ij.measure.ResultsTable}.
+ *
+ * @author Alison Walter
+ */
+public final class TableToResultsTableConverters {
+
+	private TableToResultsTableConverters() {
+		// Prevent instantiation of base class
+	}
+
+	/**
+	 * Abstract base class for converting {@link Table} to
+	 * {@link ij.measure.ResultsTable}.
+	 * <p>
+	 * Converters which extend this class will return {@code null} if the given
+	 * {@link Table} contains duplicate column headings.
+	 * </p>
+	 *
+	 * @param <A> Type of {@link Table} being converted
+	 */
+	public static abstract class AbstractTableToResultsTableConverter<A extends Table<?, ?>>
+		extends AbstractConverter<A, ij.measure.ResultsTable>
+	{
+
+		@Parameter
+		private ConvertService convert;
+
+		@Parameter
+		private LogService log;
+
+		@Override
+		public Class<ij.measure.ResultsTable> getOutputType() {
+			return ij.measure.ResultsTable.class;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> T convert(final Object src, final Class<T> dest) {
+			if (!Table.class.isInstance(src)) throw new IllegalArgumentException(
+				"Cannot convert " + src.getClass() + " to ij.measure.ResultsTable");
+
+			if (containsDuplicateHeadings((Table<?, ?>) src)) log.warn(
+				"Table has duplicate column headings.");
+
+			return (T) new TableWrapper((Table<?, ?>) src, convert);
+		}
+
+		private boolean containsDuplicateHeadings(final Table<?, ?> table) {
+			final List<String> headings = new ArrayList<>();
+			for (int c = 0; c < table.getColumnCount(); c++) {
+				final String heading = table.getColumnHeader(c);
+				if (heading == null || heading.isEmpty()) continue;
+				if (headings.contains(heading)) return true;
+				headings.add(heading);
+			}
+			return false;
+		}
+	}
+
+	/** Converts a {@link ByteTable} to a {@link ij.measure.ResultsTable}. */
+	@Plugin(type = Converter.class)
+	public static final class ByteTableToResultsTable extends
+		AbstractTableToResultsTableConverter<ByteTable>
+	{
+
+		@Override
+		public Class<ByteTable> getInputType() {
+			return ByteTable.class;
+		}
+	}
+
+	/** Converts a {@link FloatTable} to a {@link ij.measure.ResultsTable}. */
+	@Plugin(type = Converter.class)
+	public static final class FloatTableToResultsTable extends
+		AbstractTableToResultsTableConverter<FloatTable>
+	{
+
+		@Override
+		public Class<FloatTable> getInputType() {
+			return FloatTable.class;
+		}
+	}
+
+	/**
+	 * Converts a {@link GenericTable} to a {@link ij.measure.ResultsTable}. This
+	 * converter will only match if all the {@link Column}s in the table are
+	 * supported types.
+	 */
+	@Plugin(type = Converter.class)
+	public static final class GenericTableToResultsTable extends
+		AbstractTableToResultsTableConverter<GenericTable>
+	{
+
+		@Override
+		public boolean canConvert(final Object src, final Type dest) {
+			return super.canConvert(src, dest) && supportedColumnTypes(
+				(GenericTable) src);
+		}
+
+		@Override
+		public boolean canConvert(final Object src, final Class<?> dest) {
+			return super.canConvert(src, dest) && supportedColumnTypes(
+				(GenericTable) src);
+		}
+
+		@Override
+		public Class<GenericTable> getInputType() {
+			return GenericTable.class;
+		}
+
+		private boolean supportedColumnTypes(final GenericTable table) {
+			for (int c = 0; c < table.getColumnCount(); c++) {
+				final Column<?> col = table.get(c);
+				if (Number.class.isAssignableFrom(col.getType()) || col
+					.getType() == String.class || col.getType() == Object.class) continue;
+				return false;
+			}
+			return true;
+		}
+	}
+
+	/** Converts a {@link IntTable} to a {@link ij.measure.ResultsTable}. */
+	@Plugin(type = Converter.class)
+	public static final class IntTableToResultsTable extends
+		AbstractTableToResultsTableConverter<IntTable>
+	{
+
+		@Override
+		public Class<IntTable> getInputType() {
+			return IntTable.class;
+		}
+	}
+
+	/** Converts a {@link LongTable} to a {@link ij.measure.ResultsTable}. */
+	@Plugin(type = Converter.class)
+	public static final class LongTableToResultsTable extends
+		AbstractTableToResultsTableConverter<LongTable>
+	{
+
+		@Override
+		public Class<LongTable> getInputType() {
+			return LongTable.class;
+		}
+	}
+
+	/** Converts a {@link ResultsTable} to a {@link ij.measure.ResultsTable}. */
+	@Plugin(type = Converter.class)
+	public static final class ResultsTableToResultsTable extends
+		AbstractTableToResultsTableConverter<ResultsTable>
+	{
+
+		@Override
+		public Class<ResultsTable> getInputType() {
+			return ResultsTable.class;
+		}
+	}
+
+	/** Converts a {@link ShortTable} to a {@link ij.measure.ResultsTable}. */
+	@Plugin(type = Converter.class)
+	public static final class ShortTableToResultsTable extends
+		AbstractTableToResultsTableConverter<ShortTable>
+	{
+
+		@Override
+		public Class<ShortTable> getInputType() {
+			return ShortTable.class;
+		}
+	}
+
+}

--- a/src/main/java/net/imagej/legacy/convert/TableUnwrapper.java
+++ b/src/main/java/net/imagej/legacy/convert/TableUnwrapper.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import net.imagej.table.Table;
+
+import org.scijava.Priority;
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Converts a {@link TableWrapper} to a {@link Table}, by unwrapping it.
+ *
+ * @author Alison Walter
+ */
+@Plugin(type = Converter.class, priority = Priority.VERY_HIGH)
+public class TableUnwrapper extends
+	AbstractConverter<TableWrapper, Table<?, ?>>
+{
+
+	@Override
+	public Class<TableWrapper> getInputType() {
+		return TableWrapper.class;
+	}
+
+	@Override
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public Class<Table<?, ?>> getOutputType() {
+		return (Class) Table.class;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T convert(final Object src, final Class<T> dest) {
+		if (!getInputType().isInstance(src)) throw new IllegalArgumentException(src
+			.getClass() + " is not instance of input type: " + getInputType());
+
+		return (T) ((TableWrapper) src).getSource();
+	}
+
+}

--- a/src/main/java/net/imagej/legacy/convert/TableWrapper.java
+++ b/src/main/java/net/imagej/legacy/convert/TableWrapper.java
@@ -1,0 +1,400 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import ij.ImagePlus;
+import ij.gui.Roi;
+import ij.measure.ResultsTable;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import net.imagej.table.Column;
+import net.imagej.table.Table;
+
+import org.scijava.convert.ConvertService;
+
+/**
+ * Wraps an {@link Table} as a {@link ij.measure.ResultsTable}.
+ *
+ * @author Alison Walter
+ */
+public class TableWrapper extends ij.measure.ResultsTable {
+
+	private final Table<?, ?> source;
+	private final ConvertService convert;
+
+	public TableWrapper(final Table<?, ?> source, final ConvertService convert) {
+		super();
+		for (int r = 0; r < source.getRowCount(); r++)
+			super.incrementCounter();
+
+		this.source = source;
+		this.convert = convert;
+		synchronizeToImageJTable();
+	}
+
+	public Table<?, ?> getSource() {
+		return source;
+	}
+
+	@Override
+	public synchronized void incrementCounter() {
+		super.incrementCounter();
+		source.appendRow();
+	}
+
+	@Override
+	public synchronized void addColumns() {
+		super.addColumns();
+		final int numIJColumns = super.getLastColumn() + 1;
+		while (numIJColumns != source.getColumnCount())
+			source.appendColumn();
+	}
+
+	// NB: Technically addValue methods overwrite the value in the last row. In
+	// IJ1 it looks like when this is called incrementCounter() is called right
+	// before.
+	@Override
+	public void addValue(final int column, final double value) {
+		super.addValue(column, value);
+
+		// NB: In IJ String and double values are in separate data structures,
+		// so when String values are set the corresponding position in the double
+		// structure is set to NaN. These are all in one structure in ImageJ2,
+		// so if the value is NaN do not overwrite the value.
+		if (Double.isNaN(value)) return;
+		createMissingColumns(column);
+		setDoubleValue(column, source.getRowCount() - 1, value);
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public void addLabel(final String columnHeading, final String label) {
+		super.addLabel(columnHeading, label);
+		source.setRowHeader(source.getRowCount() - 1, label);
+	}
+
+	@Override
+	public void setLabel(final String label, final int row) {
+		super.setLabel(label, row);
+		source.setRowHeader(row, label);
+	}
+
+	@Override
+	public void disableRowLabels() {
+		super.disableRowLabels();
+		if (source.getRowHeader(source.getRowCount() - 1).equals("Label")) {
+			for (int r = 0; r < source.getRowCount(); r++)
+				source.setRowHeader(r, null);
+		}
+	}
+
+	@Override
+	public int getFreeColumn(final String heading) {
+		final int newColumn = super.getFreeColumn(heading);
+		createMissingColumns(newColumn);
+		if (newColumn >= 0) source.setColumnHeader(newColumn, heading);
+		return newColumn;
+	}
+
+	@Override
+	public void setValue(final int column, final int row, final double value) {
+		super.setValue(column, row, value);
+
+		// NB: In IJ String and double values are in separate data structures,
+		// so when String values are set the corresponding position in the double
+		// structure is set to NaN. These are all in one structure in ImageJ2,
+		// so if the value is NaN do not overwrite the value.
+		if (Double.isNaN(value)) return;
+		createMissingColumns(column);
+		setDoubleValue(column, row, value);
+	}
+
+	@Override
+	public void setValue(final int column, final int row, final String value) {
+		super.setValue(column, row, value);
+		createMissingColumns(column);
+		setStringValue(column, row, value);
+	}
+
+	@Override
+	@SuppressWarnings("deprecation")
+	public void setHeading(final int column, final String heading) {
+		super.setHeading(column, heading);
+		createMissingColumns(column);
+		source.setColumnHeader(column, heading);
+	}
+
+	@Override
+	public void setDefaultHeadings() {
+		super.setDefaultHeadings();
+		int count = 0;
+		while (!getDefaultHeading(count).equals("null")) {
+			source.setColumnHeader(count, getDefaultHeading(count));
+			count++;
+		}
+	}
+
+	@Override
+	public synchronized void deleteRow(final int rowIndex) {
+		super.deleteRow(rowIndex);
+		source.removeRow(rowIndex);
+	}
+
+	@Override
+	public void deleteColumn(final String column) {
+		super.deleteColumn(column);
+		source.removeColumn(column);
+	}
+
+	@Override
+	public void renameColumn(final String oldName, final String newName) {
+		super.renameColumn(oldName, newName);
+		source.get(oldName).setHeader(newName);
+	}
+
+	@Override
+	public synchronized void reset() {
+		super.reset();
+		source.clear();
+	}
+
+	@Override
+	public void update(final int measurements, final ImagePlus imp,
+		final Roi roi)
+	{
+		super.update(measurements, imp, roi);
+		synchronizeToIJTable();
+	}
+
+	@Override
+	public boolean applyMacro(final String macro) {
+		final boolean applyMacro = super.applyMacro(macro);
+		synchronizeToIJTable();
+		return applyMacro;
+	}
+
+	// -- Helper methods --
+
+	/**
+	 * Synchronizes the {@link ij.measure.ResultsTable} to be the same as the
+	 * backing {@link Table}.
+	 */
+	@SuppressWarnings("deprecation")
+	private void synchronizeToImageJTable() {
+		for (int c = 0; c < source.getColumnCount(); c++) {
+			for (int r = 0; r < source.getRowCount(); r++) {
+				final Object value = source.get(c, r);
+				if (value instanceof Number) super.setValue(c, r, ((Number) value)
+					.doubleValue());
+				else if (value instanceof String) super.setValue(c, r, (String) value);
+				else throw new IllegalArgumentException("Cannot store type " + value
+					.getClass() + " in ij.measure.ResultsTable!");
+			}
+		}
+
+		// NB: Using setValue(String, int, String) or setValue(String, int, double)
+		// does not allow null headings
+		for (int i = 0; i < source.getColumnCount(); i++)
+			super.setHeading(i, source.getColumnHeader(i));
+	}
+
+	/**
+	 * Synchronizes the backing {@link Table} to be the same as this
+	 * {@link ij.measure.ResultsTable}.
+	 */
+	private void synchronizeToIJTable() {
+		for (int c = 0; c <= getLastColumn(); c++) {
+			for (int r = 0; r < size(); r++) {
+				if (checkString(c, r)) {
+					setStringValue(c, r, getStringValue(c, r));
+				}
+				else {
+					setDoubleValue(c, r, getValueAsDouble(c, r));
+				}
+			}
+		}
+
+		for (int i = 0; i < source.getColumnCount(); i++)
+			source.setColumnHeader(i, getColumnHeading(i));
+	}
+
+	/**
+	 * Attempts to set the given location in the backing {@link Table} to a
+	 * {@code double} value. There are several cases:
+	 * <ul>
+	 * <li>Column type extends Number: the double value is converted to the type
+	 * of the column</li>
+	 * <li>Column is of type String: the double value is converted to a
+	 * String</li>
+	 * <li>Column is of type Object: the double value is just put into the
+	 * table</li>
+	 * </ul>
+	 * <p>
+	 * If the column satisfies none of the above cases an exception is thrown.
+	 * </p>
+	 *
+	 * @param column The column index of the value
+	 * @param row The row index of the value
+	 * @param value The value to be set
+	 */
+	private void setDoubleValue(final int column, final int row,
+		final double value)
+	{
+		final Column<?> col = source.get(column);
+
+		// Set value
+		if (Number.class.isAssignableFrom(col.getType())) {
+			@SuppressWarnings("unchecked")
+			final Column<Number> numberColumn = (Column<Number>) col;
+			final Number convertedValue = convert.convert(value, numberColumn
+				.getType());
+			numberColumn.set(row, convertedValue);
+		}
+		else if (col.getType() == String.class) {
+			@SuppressWarnings("unchecked")
+			final Column<String> stringColumn = (Column<String>) col;
+			stringColumn.set(row, Double.toString(value));
+		}
+		else if (col.getType() == Object.class) {
+			@SuppressWarnings("unchecked")
+			final Column<Object> objectColumn = (Column<Object>) col;
+			objectColumn.set(row, value);
+		}
+		else throw new IllegalArgumentException(
+			"Cannot add double to column of type " + col.getType());
+
+		// Set column heading
+		col.setHeader(super.getColumnHeading(column));
+	}
+
+	/**
+	 * Attempts to set the value of the backing {@link Table} at the given row and
+	 * column to a {@code String}.
+	 * <ul>
+	 * <li>Column type is String: sets the value</li>
+	 * <li>Column type is Object: sets the value</li>
+	 * </ul>
+	 * <p>
+	 * Occasionally, ImageJ 1.x will call methods which use this method to set
+	 * "space holder" values. In these cases for {@code Number} type columns their
+	 * values will be NaN or 0, and should be ignored.
+	 * </p>
+	 * <p>
+	 * If none of the above cases are satisfied an exception is thrown.
+	 * </p>
+	 *
+	 * @param column The column index of the value
+	 * @param row The row index of the value
+	 * @param value The value to be set
+	 */
+	private void setStringValue(final int column, final int row,
+		final String value)
+	{
+		final Column<?> c = source.get(column);
+
+		// NB: This method gets called from setColumn(...) which attempts to fill
+		// in empty rows with "". But before this setValue(int, int, double) is
+		// called which sets these to NaN.
+		if ((c.getType() == Double.class || c.getType() == Float.class) && c.get(
+			row).equals(Double.NaN)) return;
+		if (Number.class.isAssignableFrom(c.getType()) && c.get(row).equals(0))
+			return;
+		if (c.getType() == String.class) {
+			@SuppressWarnings("unchecked")
+			final Column<String> stringColumn = (Column<String>) c;
+			stringColumn.set(row, value);
+		}
+		else if (c.getType() == Object.class) {
+			@SuppressWarnings("unchecked")
+			final Column<Object> objectColumn = (Column<Object>) c;
+			objectColumn.set(row, value);
+		}
+		else throw new IllegalArgumentException("Cannot add String to column of " +
+			"type " + c.getType());
+	}
+
+	/**
+	 * Checks if the value at the given position is a String.
+	 *
+	 * @return true if the value at the given location is a String, otherwise
+	 *         false
+	 */
+	private boolean checkString(final int row, final int col) {
+		final double d = getValueAsDouble(col, row);
+		final String s = getStringValue(col, row);
+
+		// convert d to a string, as ResultsTable would
+		String c = "";
+		try {
+			final Field f = ij.measure.ResultsTable.class.getDeclaredField(
+				"decimalPlaces");
+			f.setAccessible(true);
+			final short[] dec = (short[]) f.get(this);
+			final short places = dec[col];
+			if (places == Short.MIN_VALUE) {
+				final Method m = super.getClass().getDeclaredMethod("n", double.class);
+				m.setAccessible(true);
+				c = (String) m.invoke(this, d);
+			}
+			else {
+				c = ResultsTable.d2s(d, dec[col]);
+			}
+		}
+		catch (final Exception exc) {
+			// if can't get the decimal places or n(...), call d2s with AUTO_FORMAT
+			c = ResultsTable.d2s(d, ij.measure.ResultsTable.AUTO_FORMAT);
+		}
+
+		// Special case for NaN
+		if (((Double) d).isNaN() && (s == "" || s == null)) return false;
+
+		return !s.equals(c);
+	}
+
+	/**
+	 * If {@code source} does not have a column at the given index, it creates
+	 * columns until there is a column for the given index.
+	 * <p>
+	 * When values are added or set in {@link ij.measure.ResultsTable}s missing
+	 * columns are created as needed.
+	 * </p>
+	 *
+	 * @param index The index to which there must be columns
+	 */
+	private void createMissingColumns(final int index) {
+		if (index < source.getColumnCount()) return;
+		while (index != (source.getColumnCount() - 1))
+			source.appendColumn();
+	}
+}

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -97,10 +97,12 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.convert.ImagePlusToDatasetConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ImagePlusToImageDisplayConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ImageTitleToImagePlusConverter.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.OverlayToROITreeConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableColumnWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableToGenericTableConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableUnwrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableWrapper.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.ROITreeToOverlayConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.StringToImagePlusConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableToResultsTableConverters.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableUnwrapper.class.getName()) ||

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -99,6 +99,7 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.convert.ImageTitleToImagePlusConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableColumnWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableToGenericTableConverter.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.ResultsTableUnwrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.StringToImagePlusConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableToResultsTableConverters.class.getName()) ||

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -101,6 +101,7 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.convert.ResultsTableToGenericTableConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.StringToImagePlusConverter.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.TableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.roi.AbstractMaskPredicateToRoiConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.roi.AbstractPolygonRoiWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.roi.AbstractRoiToMaskPredicateConverter.class.getName()) ||

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -101,6 +101,7 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.convert.ResultsTableToGenericTableConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ResultsTableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.StringToImagePlusConverter.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.TableToResultsTableConverters.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.roi.AbstractMaskPredicateToRoiConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.roi.AbstractPolygonRoiWrapper.class.getName()) ||

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -104,6 +104,7 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.convert.ResultsTableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ROITreeToOverlayConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.StringToImagePlusConverter.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.TableListWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableToResultsTableConverters.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableUnwrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableWrapper.class.getName()) ||

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -102,6 +102,7 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.convert.ResultsTableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.StringToImagePlusConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableToResultsTableConverters.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.TableUnwrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.roi.AbstractMaskPredicateToRoiConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.roi.AbstractPolygonRoiWrapper.class.getName()) ||

--- a/src/test/java/net/imagej/legacy/convert/ResultsTableConversionTest.java
+++ b/src/test/java/net/imagej/legacy/convert/ResultsTableConversionTest.java
@@ -32,6 +32,7 @@
 package net.imagej.legacy.convert;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import ij.IJ;
@@ -40,12 +41,31 @@ import ij.gui.OvalRoi;
 import ij.gui.Overlay;
 import ij.gui.Roi;
 
+import java.util.Arrays;
+
 import net.imagej.patcher.LegacyInjector;
+import net.imagej.table.BoolTable;
 import net.imagej.table.ByteTable;
 import net.imagej.table.Column;
+import net.imagej.table.DefaultBoolTable;
 import net.imagej.table.DefaultByteTable;
+import net.imagej.table.DefaultColumn;
+import net.imagej.table.DefaultFloatTable;
+import net.imagej.table.DefaultGenericTable;
+import net.imagej.table.DefaultIntTable;
+import net.imagej.table.DefaultLongTable;
+import net.imagej.table.DefaultResultsTable;
+import net.imagej.table.DefaultShortTable;
+import net.imagej.table.DoubleColumn;
+import net.imagej.table.FloatTable;
+import net.imagej.table.GenericColumn;
 import net.imagej.table.GenericTable;
+import net.imagej.table.IntTable;
+import net.imagej.table.LongTable;
+import net.imagej.table.ResultsTable;
+import net.imagej.table.ShortTable;
 import net.imagej.table.Table;
+import net.imglib2.type.numeric.integer.ByteType;
 
 import org.junit.After;
 import org.junit.Before;
@@ -286,6 +306,163 @@ public class ResultsTableConversionTest {
 		assertTablesEqual(measurements, converted);
 	}
 
+	// -- Test net.imagej.table.Table to ij.measure.ResultsTable --
+
+	@Test
+	public void testConvertDoubleTable() {
+		final Double[][] data = new Double[][] { { 10.5, 20.25, 11.0 }, { -0.125,
+			100.25, -20.5 } };
+		final ResultsTable dt = new DefaultResultsTable(data.length,
+			data[0].length);
+		populateTable(dt, data);
+
+		final ij.measure.ResultsTable ijTable = convertService.convert(dt,
+			ij.measure.ResultsTable.class);
+		assertTablesEqual(dt, ijTable);
+	}
+
+	@Test
+	public void testConvertLongTable() {
+		final Long[][] data = new Long[][] { { Long.MAX_VALUE, Long.MIN_VALUE }, {
+			0l, 100l }, { -20010l, 8l }, { 101l, 101l }, { -92l, -8000l } };
+		final LongTable lt = new DefaultLongTable(data.length, data[0].length);
+		populateTable(lt, data);
+
+		// NB: This conversion is lossy!
+		final ij.measure.ResultsTable ijTable = convertService.convert(lt,
+			ij.measure.ResultsTable.class);
+
+		int ijColumnCount = 0;
+		for (int i = 0; i <= ijTable.getLastColumn(); i++)
+			if (ijTable.columnExists(i)) ijColumnCount++;
+
+		assertEquals(lt.getColumnCount(), ijColumnCount);
+		assertEquals(lt.getRowCount(), ijTable.size());
+
+		for (int c = 0; c < lt.getColumnCount(); c++) {
+			assertEquals(lt.getColumnHeader(c), ijTable.getColumnHeading(c));
+			for (int r = 0; r < lt.getRowCount(); r++)
+				assertEquals(lt.get(c, r).longValue(), (long) ijTable.getValueAsDouble(
+					c, r));
+		}
+	}
+
+	@Test
+	public void testConvertGenericTable() {
+		final GenericTable t = createGenericTable();
+		final ij.measure.ResultsTable ijTable = convertService.convert(t,
+			ij.measure.ResultsTable.class);
+		assertTablesEqual(t, ijTable);
+	}
+
+	@Test
+	public void testConvertGenericTableMutating() {
+		final GenericTable t = createGenericTable();
+		final ij.measure.ResultsTable ijTable = convertService.convert(t,
+			ij.measure.ResultsTable.class);
+		assertTablesEqual(t, ijTable);
+
+		ijTable.incrementCounter(); // NB: addValue does not append rows
+		ijTable.addValue(2, 18);
+		assertEquals(4, t.getRowCount());
+		assertEquals(18.0, t.get(2, 3));
+
+		ijTable.addValue("heading 1", "greetings!");
+		assertEquals(4, t.getRowCount());
+		assertEquals("greetings!", t.get(0, 3));
+
+		ijTable.setValue(1, 1, "farewell");
+		assertEquals("farewell", t.get(1, 1));
+
+		ijTable.setValue(3, 0, "dog");
+		assertEquals("dog", t.get(3, 0));
+
+		ijTable.addValue(4, -144);
+		assertEquals(-144.0, t.get(4, 3));
+		assertEquals(ijTable.size(), t.get(4).size());
+		for (int i = 0; i < t.getRowCount() - 1; i++)
+			assertNull(t.get(4, i));
+
+		ijTable.setValue(4, 2, "kitten");
+		assertEquals("kitten", t.get(4, 2));
+	}
+
+	@Test
+	public void testConverterMatchingToResultsTable() {
+		// Supported
+		final ByteTable byteTable = new DefaultByteTable();
+		assertTrue(convertService.getHandler(byteTable,
+			ij.measure.ResultsTable.class) instanceof
+			TableToResultsTableConverters.ByteTableToResultsTable);
+
+		final ShortTable shortTable = new DefaultShortTable();
+		assertTrue(convertService.getHandler(shortTable,
+			ij.measure.ResultsTable.class) instanceof
+			TableToResultsTableConverters.ShortTableToResultsTable);
+
+		final IntTable intTable = new DefaultIntTable();
+		assertTrue(convertService.getHandler(intTable,
+			ij.measure.ResultsTable.class) instanceof
+			TableToResultsTableConverters.IntTableToResultsTable);
+
+		final LongTable longTable = new DefaultLongTable();
+		assertTrue(convertService.getHandler(longTable,
+			ij.measure.ResultsTable.class) instanceof
+			TableToResultsTableConverters.LongTableToResultsTable);
+
+		final FloatTable floatTable = new DefaultFloatTable();
+		assertTrue(convertService.getHandler(floatTable,
+			ij.measure.ResultsTable.class) instanceof
+			TableToResultsTableConverters.FloatTableToResultsTable);
+
+		final ResultsTable doubleTable = new DefaultResultsTable();
+		assertTrue(convertService.getHandler(doubleTable,
+			ij.measure.ResultsTable.class) instanceof
+			TableToResultsTableConverters.ResultsTableToResultsTable);
+
+		final GenericTable genericTable = new DefaultGenericTable();
+		assertTrue(convertService.getHandler(genericTable,
+			ij.measure.ResultsTable.class) instanceof
+			TableToResultsTableConverters.GenericTableToResultsTable);
+
+		// Type not supported
+		final BoolTable boolTable = new DefaultBoolTable();
+		assertNull(convertService.getHandler(boolTable,
+			ij.measure.ResultsTable.class));
+
+		// Not supported: Generic table w/ non-String/Double values
+		final GenericTable invalidTable = createGenericTable();
+		final Column<ByteType> byteTypeColumn = new DefaultColumn<>(ByteType.class);
+		byteTypeColumn.addAll(Arrays.asList(new ByteType((byte) 122), new ByteType(
+			(byte) -1), new ByteType((byte) -30)));
+		invalidTable.add(byteTypeColumn);
+		assertNull(convertService.getHandler(invalidTable,
+			ij.measure.ResultsTable.class));
+	}
+
+	@Test
+	public void testDuplicateHeadings() {
+		// NB: You can create tables with duplicate heading in IJ1, but it may
+		// affect the behavior of the table later on.
+		final ByteTable duplicateHeadings = new DefaultByteTable(2, 3);
+		duplicateHeadings.setColumnHeader(0, "heading");
+		duplicateHeadings.setColumnHeader(1, "heading");
+		assertTrue(convertService.getHandler(duplicateHeadings,
+			ij.measure.ResultsTable.class) instanceof
+			TableToResultsTableConverters.ByteTableToResultsTable);
+		final ij.measure.ResultsTable rt = convertService.convert(duplicateHeadings,
+			ij.measure.ResultsTable.class);
+
+		assertTablesEqual(duplicateHeadings, rt);
+	}
+
+	@Test
+	public void testResultsTableUnwrapping() {
+		final Table<?, ?> wrapped = new ResultsTableWrapper(table);
+		assertTrue(convertService.getHandler(wrapped,
+			ij.measure.ResultsTable.class) instanceof ResultsTableUnwrapper);
+	}
+
 	// -- Helper methods --
 
 	private void assertTablesEqual(final ij.measure.ResultsTable expected,
@@ -313,6 +490,34 @@ public class ResultsTableConversionTest {
 		}
 	}
 
+	private void assertTablesEqual(final Table<?, ?> expected,
+		final ij.measure.ResultsTable actual)
+	{
+		int ijColumnCount = 0;
+		for (int i = 0; i <= actual.getLastColumn(); i++)
+			if (actual.columnExists(i)) ijColumnCount++;
+
+		assertEquals(expected.getColumnCount(), ijColumnCount);
+		assertEquals(expected.getRowCount(), actual.size());
+
+		for (int c = 0; c < expected.getColumnCount(); c++) {
+			assertEquals(expected.getColumnHeader(c), actual.getColumnHeading(c));
+			for (int r = 0; r < expected.getRowCount(); r++) {
+				final Object expectedValue = expected.get(c, r);
+				if (expectedValue instanceof String) assertEquals(expectedValue, actual
+					.getStringValue(c, r));
+				else if (expectedValue instanceof Double ||
+					expectedValue instanceof Float) assertEquals(expectedValue, actual
+						.getValueAsDouble(c, r));
+				else if (expectedValue instanceof Number) assertEquals(
+					((Number) expectedValue).longValue(), (long) actual.getValueAsDouble(
+						c, r));
+				else throw new IllegalArgumentException("Unknown type: " + expectedValue
+					.getClass());
+			}
+		}
+	}
+
 	private <T, C extends Column<T>> void populateTable(final Table<C, T> t,
 		final T[][] data)
 	{
@@ -321,5 +526,27 @@ public class ResultsTableConversionTest {
 				t.set(c, r, data[c][r]);
 			}
 		}
+	}
+
+	private GenericTable createGenericTable() {
+		final Column<String> stringCol = new DefaultColumn<>(String.class,
+			"heading 1");
+		final Column<String> stringColTwo = new DefaultColumn<>(String.class,
+			"heading 2");
+		final DoubleColumn doubleCol = new DoubleColumn("heading 3");
+		final GenericColumn mixedCol = new GenericColumn("heading 4");
+
+		stringCol.addAll(Arrays.asList("hello", "hi", "hey"));
+		stringColTwo.addAll(Arrays.asList("bye", "see ya!", "later"));
+		doubleCol.fill(new double[] { 100.125, 0, -30209.25 });
+		mixedCol.addAll(Arrays.asList("cats", Byte.MAX_VALUE, 0.25));
+
+		final GenericTable t = new DefaultGenericTable();
+		t.add(stringCol);
+		t.add(stringColTwo);
+		t.add(doubleCol);
+		t.add(mixedCol);
+
+		return t;
 	}
 }

--- a/src/test/java/net/imagej/legacy/convert/ResultsTableConversionTest.java
+++ b/src/test/java/net/imagej/legacy/convert/ResultsTableConversionTest.java
@@ -39,7 +39,6 @@ import ij.ImagePlus;
 import ij.gui.OvalRoi;
 import ij.gui.Overlay;
 import ij.gui.Roi;
-import ij.measure.ResultsTable;
 
 import net.imagej.patcher.LegacyInjector;
 import net.imagej.table.ByteTable;
@@ -66,7 +65,7 @@ public class ResultsTableConversionTest {
 		LegacyInjector.preinit();
 	}
 
-	private ResultsTable table;
+	private ij.measure.ResultsTable table;
 
 	private final String[] headings = { "col 1", "col2", "col-3", "col_4",
 		"col 5" };
@@ -90,7 +89,7 @@ public class ResultsTableConversionTest {
 		context = new Context(ConvertService.class);
 		convertService = context.getService(ConvertService.class);
 
-		table = new ResultsTable();
+		table = new ij.measure.ResultsTable();
 
 		for (int i = 0; i < headings.length; i++) {
 			for (int j = 0; j < rowLabels.length; j++) {
@@ -262,7 +261,7 @@ public class ResultsTableConversionTest {
 			4, 5 }, { -50, -51, -52 } };
 		final ByteTable bt = new DefaultByteTable(4, 3);
 		populateTable(bt, data);
-		final ResultsTable rt = new TableWrapper(bt, convertService);
+		final ij.measure.ResultsTable rt = new TableWrapper(bt, convertService);
 
 		final Converter<?, ?> c = convertService.getHandler(rt, Table.class);
 		assertTrue(c instanceof TableUnwrapper);
@@ -280,7 +279,7 @@ public class ResultsTableConversionTest {
 
 		final ImagePlus imagePlus = IJ.createImage("gradient", "8-bit ramp", 200,
 			200, 5);
-		final ResultsTable measurements = overlay.measure(imagePlus);
+		final ij.measure.ResultsTable measurements = overlay.measure(imagePlus);
 
 		final Table<?, ?> converted = convertService.convert(measurements,
 			Table.class);


### PR DESCRIPTION
Hello!

This PR makes the following changes:
* Fixes bugs with `Table` to `ij.measure.ResultsTable` conversion
  * Namely handling null columns
* Adds converters and wrapper for `ij.measure.ResultsTable` to `Table`
* Adds converters to unwrap, wrapped tables
* Adds `TableListWrapper` for wrapping `List<Table<?, ?>>` as `List<ij.measure.ResultsTable>`
* Adds `Overlay` to `ROITree` converters (and vice versa)
* Modifies `LegacyImageMap` to synchronize attached ROIs and tables when going between `ImagePlus` and `Dataset`

**Notes:**
1. Why have converters between `Overlay` and `ROITree` but not `List<Table<?, ?>>` and `List<ij.measure.ResultsTable>` converters?
    * The current convert structure does not handle types well. So the converter would be matched as a `List` to `List` converter, and there'd need to be a bunch of checking to ensure the `List`s were actually the correct type.
   * In `imagej-omero-legacy`, I need to be able to override the conversion behavior of `ROITree` to `Overlay` conversions (and vice versa). I do not need this for tables.
2. Why create `TableListWrapper`?
    * This way each `Table<?, ?>` in the `List` is only converted if necessary.
    * In `imagej-omero`, tables are lazily loaded from the OMERO server only when requested. So if I iterated this `List` to convert all the tables, I'd be loading them from OMERO even if I have no intention of using them.
3. If there's a `TableListWrapper`, why not have a `ROITreeWrapper` which is an Overlay that only converts the ROIs as needed?
    * When `setOverlay()` is called on an `ImagePlus` the canvas is repainted which causes the ROIs in the `Overlay` to be iterated and painted. So they'd get converted right away anyway in most cases.

Please feel free to let me know if you have any questions/concerns regarding these changes. All commits compile with passing tests.

Cheers,
Alison
