### PR TITLE
add auto-completion list entries from module service

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/MacroLanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroLanguageSupportPlugin.java
@@ -40,6 +40,9 @@ import javax.swing.SwingUtilities;
 import org.fife.rsta.ac.AbstractLanguageSupport;
 import org.fife.ui.autocomplete.AutoCompletion;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
+import org.fife.ui.rtextarea.ToolTipSupplier;
+import org.scijava.module.ModuleService;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.swing.script.LanguageSupportPlugin;
 
@@ -55,6 +58,9 @@ import org.scijava.ui.swing.script.LanguageSupportPlugin;
 public class MacroLanguageSupportPlugin extends AbstractLanguageSupport
 	implements LanguageSupportPlugin
 {
+	@Parameter
+	ModuleService moduleService;
+
 	private final static int MINIMUM_WORD_LENGTH_TO_OPEN_PULLDOWN = 1;
 
 	@Override
@@ -64,8 +70,7 @@ public class MacroLanguageSupportPlugin extends AbstractLanguageSupport
 
 	@Override
 	public void install(final RSyntaxTextArea rSyntaxTextArea) {
-		final AutoCompletion ac = createAutoCompletion(MacroAutoCompletionProvider
-			.getInstance());
+		final AutoCompletion ac = createAutoCompletion(getMacroAutoCompletionProvider());
 		ac.setAutoActivationDelay(100);
 		ac.setAutoActivationEnabled(true);
 		ac.setShowDescWindow(true);
@@ -75,8 +80,15 @@ public class MacroLanguageSupportPlugin extends AbstractLanguageSupport
 		rSyntaxTextArea.addKeyListener(new MacroAutoCompletionKeyListener(ac,
 			rSyntaxTextArea));
 
-		rSyntaxTextArea.setToolTipSupplier(MacroAutoCompletionProvider
-			.getInstance());
+		rSyntaxTextArea.setToolTipSupplier(getMacroAutoCompletionProvider());
+	}
+
+	private MacroAutoCompletionProvider getMacroAutoCompletionProvider() {
+		MacroAutoCompletionProvider provider = MacroAutoCompletionProvider
+				.getInstance();
+		provider.addModuleCompletions(moduleService);
+
+		return provider;
 	}
 
 	@Override


### PR DESCRIPTION
Hey guys,

here comes the auto-completion extension for IJ macros `run("Whatever")` commands as suggested on the forum:
http://forum.imagej.net/t/auto-code-completion-for-ij-macro/11642/21

The help-text links to the imagej wiki search.

For now, it will only work with simple commands as it is quite complicated to read out parameters and default values from modules. But it's better than nothing I guess.

If some of you could just quickly confirm that it works, that would be nice.
![image](https://user-images.githubusercontent.com/12660498/42027482-1db0963a-7aca-11e8-858f-b82d8fc22e9a.png)

Thanks again for your support! That was a spontaneous project which passes through like a charm!

Cheers,
Robert
