### PR TITLE
RoiManagerPreprocessor: use RoiManager.getRoiManager()

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/RoiManagerPreprocessor.java
+++ b/src/main/java/net/imagej/legacy/plugin/RoiManagerPreprocessor.java
@@ -35,8 +35,11 @@ import ij.plugin.frame.RoiManager;
 
 import org.scijava.Priority;
 import org.scijava.module.Module;
+import org.scijava.module.ModuleItem;
+import org.scijava.module.ModuleService;
 import org.scijava.module.process.AbstractSingleInputPreprocessor;
 import org.scijava.module.process.PreprocessorPlugin;
+import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 
 /**
@@ -47,18 +50,28 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = PreprocessorPlugin.class, priority = Priority.VERY_HIGH)
 public class RoiManagerPreprocessor extends AbstractSingleInputPreprocessor {
+	
+	@Parameter
+	private ModuleService moduleService;
 
 	// -- ModuleProcessor methods --
 
 	@Override
 	public void process(final Module module) {
 		// assign singleton RoiManager to single RoiManager input
-		final String roiManagerInput = getSingleInput(module, RoiManager.class);
+		final ModuleItem<RoiManager> roiManagerInput = moduleService.getSingleInput(
+			module, RoiManager.class);
 		if (roiManagerInput != null) {
-			final RoiManager roiManager = RoiManager.getInstance();
+			RoiManager roiManager;
+			if (roiManagerInput.isRequired()) {
+				roiManager = RoiManager.getRoiManager();
+			}
+			else {
+				roiManager = RoiManager.getInstance();
+			}
 			if (roiManager == null) return;
-			module.setInput(roiManagerInput, roiManager);
-			module.resolveInput(roiManagerInput);
+			module.setInput(roiManagerInput.getName(), roiManager);
+			module.resolveInput(roiManagerInput.getName());
 		}
 	}
 }


### PR DESCRIPTION
`RoiManager.getInstance()` returns `null` if no ROI Manager is open. When using a required input parameter, it might be desirable to always get a `RoiManager` object, so let's use `getRoiManager()` which creates a new instance if no `RoiManager` is present.

This helps avoiding common cases like:

```python
rm = RoiManager.getInstance()
if not rm:
	rm = RoiManager()
```

Instead of the above, you can now write this:

```
#@ RoiManager rm
```

If you rather want to get `null` instead of a `new RoiManager()`, you can still mark the input as `required=false`:

```
#@ RoiManager (required=false) rm
```
