### PR TITLE
Speed up display of SCIFIOCellImg (depends on PR in imglib2-ij)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<jmh.version>1.19</jmh.version>
 		<jmh-core.version>${jmh.version}</jmh-core.version>
 		<jmh-generator-annprocess.version>${jmh.version}</jmh-generator-annprocess.version>
+		<imglib2-ij.version>2.0.0-beta-44-SNAPSHOT</imglib2-ij.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/imagej/legacy/translate/ImagePlusCreator.java
+++ b/src/main/java/net/imagej/legacy/translate/ImagePlusCreator.java
@@ -40,6 +40,7 @@ import net.imagej.axis.Axes;
 import net.imagej.display.ImageDisplay;
 import net.imagej.display.ImageDisplayService;
 import net.imglib2.img.display.imagej.ArrayImgToVirtualStack;
+import net.imglib2.img.display.imagej.CellImgToVirtualStack;
 import net.imglib2.img.display.imagej.ImgPlusViews;
 import net.imglib2.img.display.imagej.ImgToVirtualStack;
 import net.imglib2.img.display.imagej.PlanarImgToVirtualStack;
@@ -110,6 +111,8 @@ public class ImagePlusCreator extends AbstractContextual
 	private static ImagePlus createImagePlus( Dataset dataset )
 	{
 		ImgPlus< ? extends RealType< ? > > imgPlus = dataset.getImgPlus();
+		if( CellImgToVirtualStack.isSupported( imgPlus ) )
+			return CellImgToVirtualStack.wrap( imgPlus );
 		if( PlanarImgToVirtualStack.isSupported( imgPlus ) )
 			return PlanarImgToVirtualStack.wrap( imgPlus );
 		if( ArrayImgToVirtualStack.isSupported( imgPlus ) )

--- a/src/test/java/net/imagej/legacy/translate/ImagePlusCreatorBenchmark.java
+++ b/src/test/java/net/imagej/legacy/translate/ImagePlusCreatorBenchmark.java
@@ -77,6 +77,7 @@ public class ImagePlusCreatorBenchmark
 	private final Dataset deepPlanarImg = makeDataset( PlanarImgs.unsignedBytes( deepDims ) );
 	private final Dataset small2dArrayImg = makeDataset( ArrayImgs.unsignedBytes( 10, 10 ) );
 	private final Dataset big2dArrayImg = makeDataset( ArrayImgs.unsignedBytes( 10000, 10000 ) );
+	private final Dataset cubicCellImgWithPlanarCells = makeDataset( new CellImgFactory<>( new UnsignedByteType(), 1000, 1000, 1 ).create( cubicDims ) );
 
 	@Benchmark
 	public void testSmallCellImg() {
@@ -116,6 +117,11 @@ public class ImagePlusCreatorBenchmark
 	@Benchmark
 	public void testLarge2dArrayImg() {
 		creator.createLegacyImage( big2dArrayImg );
+	}
+
+	@Benchmark
+	public void testCubicCellImageWithPlanarCells() {
+		creator.createLegacyImage( cubicCellImgWithPlanarCells );
 	}
 
 	private Dataset makeDataset( Img< UnsignedByteType > deepPlanarImg )


### PR DESCRIPTION
This PR depends on a PR in imglib2-ij: https://github.com/imglib/imglib2-ij/pull/22

A cell image with planar cells has the same memory organization as an ImagePlus.
SCIFIOCellImage (which often or allways??) uses planar cells can therefor converted to ImagePlus without the copying of any pixel buffer. This PR removes such superfluous copy operation, and should result in a faster display of SCIFIOCellImg and faster operations with legacy code.