### PR TITLE
fixing two null pointer exceptions in case the IJ1Helper is not set

### DIFF
--- a/src/main/java/net/imagej/legacy/DefaultLegacyHooks.java
+++ b/src/main/java/net/imagej/legacy/DefaultLegacyHooks.java
@@ -152,7 +152,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 					final Object o = interceptFileOpen(null);
 					if (o != null) {
 						if (o instanceof String) {
-							legacyService.getIJ1Helper().openPathDirectly((String) o);
+							helper.openPathDirectly((String) o);
 						}
 						return o;
 					}
@@ -448,7 +448,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 			final Window win = windows[w];
 
 			// Skip the ImageJ 1.x main window
-			if (win == null || win == legacyService.getIJ1Helper().getIJ()) {
+			if (win == null || win == helper.getIJ()) {
 				continue;
 			}
 
@@ -496,12 +496,11 @@ public class DefaultLegacyHooks extends LegacyHooks {
 
 	@Override
 	public void interceptImageWindowClose(final Object window) {
-		final IJ1Helper ij1Helper = legacyService.getIJ1Helper();
 		final Frame w = (Frame)window;
 		// When quitting, IJ1 doesn't dispose closing ImageWindows.
 		// If the quit is later canceled this would leave orphaned windows.
 		// Thus we queue any closed windows for disposal.
-		if (ij1Helper.isWindowClosed(w) && ij1Helper.quitting()) {
+		if (helper.isWindowClosed(w) && helper.quitting()) {
 			threadService().queue(new Runnable() {
 				@Override
 				public void run() {
@@ -517,7 +516,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 		// within its ij.ImageJ#run() method, which is typically, but not always,
 		// called on a separate thread by ij.ImageJ#quit(). The question is: did
 		// the shutdown originate from an IJ1 code path, or a SciJava one?
-		if (legacyService.getIJ1Helper().isDisposing()) {
+		if (helper.isDisposing()) {
 			// NB: ImageJ1 is in the process of a hard shutdown via an API call on
 			// the SciJava level. It was probably either LegacyService#dispose() or
 			// LegacyUI#dispose(), either of which triggers IJ1Helper#dispose().

--- a/src/main/java/net/imagej/legacy/command/LegacyCommandFinder.java
+++ b/src/main/java/net/imagej/legacy/command/LegacyCommandFinder.java
@@ -41,6 +41,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
+import net.imagej.legacy.IJ1Helper;
 import net.imagej.legacy.LegacyService;
 
 import org.scijava.MenuEntry;
@@ -71,11 +72,14 @@ public class LegacyCommandFinder {
 
 	public List<CommandInfo> findCommands() {
 		final List<CommandInfo> infos = new ArrayList<>();
+
+		if (legacyService == null) return infos;
+		final IJ1Helper ij1Helper = legacyService.getIJ1Helper();
+		if (ij1Helper == null) return infos;
+
 		final Map<String, MenuPath> menuTable = parseMenus();
-		final Hashtable<String, String> commands = //
-			legacyService.getIJ1Helper().getCommands();
-		final ClassLoader classLoader = //
-			legacyService.getIJ1Helper().getClassLoader();
+		final Hashtable<String, String> commands = ij1Helper.getCommands();
+		final ClassLoader classLoader = ij1Helper.getClassLoader();
 		for (final String key : commands.keySet()) {
 			final CommandInfo pe = createEntry(key, commands, menuTable, classLoader);
 			if (pe != null) infos.add(pe);

--- a/src/main/java/net/imagej/legacy/convert/AbstractLegacyConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/AbstractLegacyConverter.java
@@ -31,57 +31,32 @@
 
 package net.imagej.legacy.convert;
 
-import ij.ImagePlus;
+import net.imagej.legacy.LegacyService;
 
-import java.util.Collection;
-
-import net.imagej.display.ImageDisplay;
-
-import org.scijava.Priority;
+import org.scijava.convert.AbstractConverter;
 import org.scijava.convert.Converter;
-import org.scijava.object.ObjectService;
 import org.scijava.plugin.Parameter;
-import org.scijava.plugin.Plugin;
 
 /**
- * {@link Converter} implementation for converting {@link ImageDisplay} to an
- * {@link ImagePlus}.
+ * Base {@link Converter} class for converting ImageJ 1.x data structures.
  *
  * @author Curtis Rueden
  */
-@Plugin(type = Converter.class, priority = Priority.LOW)
-public class ImageDisplayToImagePlusConverter extends
-	AbstractLegacyConverter<ImageDisplay, ImagePlus>
-{
+public abstract class AbstractLegacyConverter<I, O> extends AbstractConverter<I, O> {
 
 	@Parameter(required = false)
-	private ObjectService objectService;
-
-	// -- Converter methods --
+	protected LegacyService legacyService;
 
 	@Override
-	public <T> T convert(final Object src, final Class<T> dest) {
-		if (!legacyEnabled()) throw new UnsupportedOperationException();
-		final ImageDisplay display = (ImageDisplay) src;
-		final Object imp = legacyService.getImageMap().registerDisplay(display);
-		@SuppressWarnings("unchecked")
-		final T typedImp = (T) imp;
-		return typedImp;
+	public boolean canConvert(final Class<?> src, final Class<?> dest) {
+		return legacyEnabled() && super.canConvert(src, dest);
 	}
 
-	@Override
-	public void populateInputCandidates(final Collection<Object> objects) {
-		if (objectService == null) return;
-		objects.addAll(objectService.getObjects(ImageDisplay.class));
-	}
+	// -- Internal methods --
 
-	@Override
-	public Class<ImagePlus> getOutputType() {
-		return ImagePlus.class;
-	}
-
-	@Override
-	public Class<ImageDisplay> getInputType() {
-		return ImageDisplay.class;
+	protected boolean legacyEnabled() {
+		return legacyService != null && //
+			legacyService.getIJ1Helper() != null && //
+			legacyService.getImageMap() != null;
 	}
 }

--- a/src/main/java/net/imagej/legacy/convert/DatasetToImagePlusConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/DatasetToImagePlusConverter.java
@@ -33,20 +33,15 @@ package net.imagej.legacy.convert;
 
 import ij.ImagePlus;
 
-import java.lang.reflect.Type;
 import java.util.Collection;
 
 import net.imagej.Dataset;
-import net.imagej.legacy.LegacyService;
 
 import org.scijava.Priority;
-import org.scijava.convert.AbstractConverter;
 import org.scijava.convert.Converter;
 import org.scijava.object.ObjectService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.util.ConversionUtils;
-import org.scijava.util.GenericUtils;
 
 /**
  * {@link Converter} implementation for converting {@link Dataset} to a
@@ -57,14 +52,12 @@ import org.scijava.util.GenericUtils;
  * </p>
  *
  * @author Mark Hiner
+ * @author Curtis Rueden
  */
 @Plugin(type = Converter.class, priority = Priority.LOW)
 public class DatasetToImagePlusConverter extends
-	AbstractConverter<Dataset, ImagePlus>
+	AbstractLegacyConverter<Dataset, ImagePlus>
 {
-
-	@Parameter(required = false)
-	private LegacyService legacyService;
 
 	@Parameter(required = false)
 	private ObjectService objectService;
@@ -72,39 +65,13 @@ public class DatasetToImagePlusConverter extends
 	// -- Converter methods --
 
 	@Override
-	public boolean canConvert(final Class<?> src, final Type dest) {
-		return canConvert(src, GenericUtils.getClass(dest));
-	}
-
-	@Override
-	public boolean canConvert(final Class<?> src, final Class<?> dest) {
-		if (legacyService == null || legacyService.getIJ1Helper() == null) return false;
-		return ConversionUtils.canCast(src, Dataset.class) &&
-			legacyService.getIJ1Helper().isImagePlus(dest);
-	}
-
-	@Override
-	public boolean canConvert(final Object src, final Type dest) {
-		return canConvert(src.getClass(), dest);
-	}
-
-	@Override
-	public boolean canConvert(final Object src, final Class<?> dest) {
-		return canConvert(src.getClass(), dest);
-	}
-
-	@Override
-	public Object convert(final Object src, final Type dest) {
-		return convert(src, GenericUtils.getClass(dest));
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
 	public <T> T convert(final Object src, final Class<T> dest) {
-		if (legacyService == null) throw new UnsupportedOperationException();
+		if (!legacyEnabled()) throw new UnsupportedOperationException();
 		final Dataset d = (Dataset) src;
 		final Object imp = legacyService.getImageMap().registerDataset(d);
-		return (T) imp;
+		@SuppressWarnings("unchecked")
+		final T typedImp = (T) imp;
+		return typedImp;
 	}
 
 	@Override

--- a/src/main/java/net/imagej/legacy/convert/DatasetToImagePlusConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/DatasetToImagePlusConverter.java
@@ -78,7 +78,7 @@ public class DatasetToImagePlusConverter extends
 
 	@Override
 	public boolean canConvert(final Class<?> src, final Class<?> dest) {
-		if (legacyService == null) return false;
+		if (legacyService == null || legacyService.getIJ1Helper() == null) return false;
 		return ConversionUtils.canCast(src, Dataset.class) &&
 			legacyService.getIJ1Helper().isImagePlus(dest);
 	}

--- a/src/main/java/net/imagej/legacy/convert/DoubleToImagePlusConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/DoubleToImagePlusConverter.java
@@ -34,7 +34,6 @@ package net.imagej.legacy.convert;
 import ij.ImagePlus;
 import ij.WindowManager;
 
-import org.scijava.convert.AbstractConverter;
 import org.scijava.convert.Converter;
 import org.scijava.plugin.Plugin;
 
@@ -60,27 +59,25 @@ import org.scijava.plugin.Plugin;
  */
 @Plugin(type = Converter.class)
 public class DoubleToImagePlusConverter extends
-	AbstractConverter<Double, ImagePlus>
+	AbstractLegacyConverter<Double, ImagePlus>
 {
 
 	// -- Converter methods --
 
 	@Override
 	public boolean canConvert(final Object src, final Class<?> dest) {
-		return convert(src, ImagePlus.class) != null;
+		return legacyEnabled() && convert(src, ImagePlus.class) != null;
 	}
 
 	@Override
 	public <T> T convert(final Object src, final Class<T> dest) {
+		if (!legacyEnabled()) throw new UnsupportedOperationException();
 		if (!(src instanceof Double)) return null;
 		final Double imageID = (Double) src;
 		final ImagePlus imp = WindowManager.getImage(imageID.intValue());
-		if (imp != null) {
-			@SuppressWarnings("unchecked")
-			final T typedImp = (T) imp;
-			return typedImp;
-		}
-		return null;
+		@SuppressWarnings("unchecked")
+		final T typedImp = (T) imp;
+		return typedImp;
 	}
 
 	@Override

--- a/src/main/java/net/imagej/legacy/convert/ImagePlusToDatasetConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/ImagePlusToDatasetConverter.java
@@ -33,23 +33,18 @@ package net.imagej.legacy.convert;
 
 import ij.ImagePlus;
 
-import java.lang.reflect.Type;
 import java.util.Collection;
 
 import net.imagej.Dataset;
 import net.imagej.display.ImageDisplay;
 import net.imagej.display.ImageDisplayService;
 import net.imagej.legacy.IJ1Helper;
-import net.imagej.legacy.LegacyService;
 
 import org.scijava.Priority;
-import org.scijava.convert.AbstractConverter;
 import org.scijava.convert.Converter;
 import org.scijava.object.ObjectService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.util.ConversionUtils;
-import org.scijava.util.GenericUtils;
 
 /**
  * {@link Converter} implementation for converting {@link ImagePlus} to a
@@ -60,54 +55,25 @@ import org.scijava.util.GenericUtils;
  * </p>
  *
  * @author Mark Hiner
+ * @author Curtis Rueden
  */
 @Plugin(type = Converter.class, priority = Priority.LOW)
 public class ImagePlusToDatasetConverter extends
-	AbstractConverter<ImagePlus, Dataset>
+	AbstractLegacyConverter<ImagePlus, Dataset>
 {
 
 	@Parameter(required = false)
 	private ImageDisplayService imageDisplayService;
 
 	@Parameter(required = false)
-	private LegacyService legacyService;
-
-	@Parameter(required = false)
 	private ObjectService objectService;
 
 	// -- Converter methods --
 
-	@Override
-	public boolean canConvert(final Class<?> src, final Type dest) {
-		return canConvert(src, GenericUtils.getClass(dest));
-	}
-
-	@Override
-	public boolean canConvert(final Class<?> src, final Class<?> dest) {
-		if (noLegacy()) return false;
-		return legacyService.getIJ1Helper().isImagePlus(src) &&
-			ConversionUtils.canCast(dest, Dataset.class);
-	}
-
-	@Override
-	public boolean canConvert(final Object src, final Type dest) {
-		return canConvert(src.getClass(), dest);
-	}
-
-	@Override
-	public boolean canConvert(final Object src, final Class<?> dest) {
-		return canConvert(src.getClass(), dest);
-	}
-
-	@Override
-	public Object convert(final Object src, final Type dest) {
-		return convert(src, GenericUtils.getClass(dest));
-	}
-
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> T convert(final Object src, final Class<T> dest) {
-		if (noLegacy() || imageDisplayService == null) {
+		if (!legacyEnabled() || imageDisplayService == null) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -121,7 +87,7 @@ public class ImagePlusToDatasetConverter extends
 
 	@Override
 	public void populateInputCandidates(final Collection<Object> objects) {
-		if (noLegacy()) return;
+		if (!legacyEnabled()) return;
 
 		final IJ1Helper ij1Helper = legacyService.getIJ1Helper();
 
@@ -146,12 +112,5 @@ public class ImagePlusToDatasetConverter extends
 	@Override
 	public Class<ImagePlus> getInputType() {
 		return ImagePlus.class;
-	}
-
-	// -- Helper methods --
-
-	private boolean noLegacy() {
-		return legacyService == null || legacyService.getIJ1Helper() == null ||
-			legacyService.getImageMap() == null;
 	}
 }

--- a/src/main/java/net/imagej/legacy/convert/ImagePlusToImageDisplayConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/ImagePlusToImageDisplayConverter.java
@@ -71,7 +71,7 @@ public class ImagePlusToImageDisplayConverter extends
 
 	@Override
 	public boolean canConvert(final Class<?> src, final Class<?> dest) {
-		if (legacyService == null) return false;
+		if (legacyService == null || legacyService.getIJ1Helper() == null) return false;
 		return legacyService.getIJ1Helper().isImagePlus(src) &&
 			ConversionUtils.canCast(dest, ImageDisplay.class);
 	}

--- a/src/main/java/net/imagej/legacy/convert/ImagePlusToImageDisplayConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/ImagePlusToImageDisplayConverter.java
@@ -33,20 +33,14 @@ package net.imagej.legacy.convert;
 
 import ij.ImagePlus;
 
-import java.lang.reflect.Type;
 import java.util.Collection;
 
 import net.imagej.display.ImageDisplay;
 import net.imagej.legacy.IJ1Helper;
-import net.imagej.legacy.LegacyService;
 
 import org.scijava.Priority;
-import org.scijava.convert.AbstractConverter;
 import org.scijava.convert.Converter;
-import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
-import org.scijava.util.ConversionUtils;
-import org.scijava.util.GenericUtils;
 
 /**
  * {@link Converter} implementation for converting {@link ImagePlus} to a
@@ -56,56 +50,27 @@ import org.scijava.util.GenericUtils;
  */
 @Plugin(type = Converter.class, priority = Priority.LOW)
 public class ImagePlusToImageDisplayConverter extends
-	AbstractConverter<ImagePlus, ImageDisplay>
+	AbstractLegacyConverter<ImagePlus, ImageDisplay>
 {
-
-	@Parameter(required = false)
-	private LegacyService legacyService;
 
 	// -- Converter methods --
 
 	@Override
-	public boolean canConvert(final Class<?> src, final Type dest) {
-		return canConvert(src, GenericUtils.getClass(dest));
-	}
-
-	@Override
-	public boolean canConvert(final Class<?> src, final Class<?> dest) {
-		if (legacyService == null || legacyService.getIJ1Helper() == null) return false;
-		return legacyService.getIJ1Helper().isImagePlus(src) &&
-			ConversionUtils.canCast(dest, ImageDisplay.class);
-	}
-
-	@Override
-	public boolean canConvert(final Object src, final Type dest) {
-		return canConvert(src.getClass(), dest);
-	}
-
-	@Override
-	public boolean canConvert(final Object src, final Class<?> dest) {
-		return canConvert(src.getClass(), dest);
-	}
-
-	@Override
-	public Object convert(final Object src, final Type dest) {
-		return convert(src, GenericUtils.getClass(dest));
-	}
-
-	@SuppressWarnings("unchecked")
-	@Override
 	public <T> T convert(final Object src, final Class<T> dest) {
-		if (legacyService == null) throw new UnsupportedOperationException();
+		if (!legacyEnabled()) throw new UnsupportedOperationException();
 
 		// Convert using the LegacyImageMap
 		final ImageDisplay display =
 			legacyService.getImageMap().registerLegacyImage((ImagePlus) src);
 
-		return (T) display;
+		@SuppressWarnings("unchecked")
+		final T typedDisplay = (T) display;
+		return typedDisplay;
 	}
 
 	@Override
 	public void populateInputCandidates(final Collection<Object> objects) {
-		if (legacyService == null) return;
+		if (!legacyEnabled()) return;
 
 		final IJ1Helper ij1Helper = legacyService.getIJ1Helper();
 

--- a/src/main/java/net/imagej/legacy/convert/ImageTitleToImagePlusConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/ImageTitleToImagePlusConverter.java
@@ -36,7 +36,6 @@ import ij.WindowManager;
 
 import java.util.Collection;
 
-import org.scijava.convert.AbstractConverter;
 import org.scijava.convert.ConvertService;
 import org.scijava.convert.Converter;
 import org.scijava.plugin.Plugin;
@@ -63,7 +62,7 @@ import org.scijava.widget.WidgetModel;
  */
 @Plugin(type = Converter.class)
 public class ImageTitleToImagePlusConverter extends
-	AbstractConverter<ImageTitleToImagePlusConverter.ImageTitle, ImagePlus>
+	AbstractLegacyConverter<ImageTitleToImagePlusConverter.ImageTitle, ImagePlus>
 {
 
 	// -- Converter methods --
@@ -71,6 +70,7 @@ public class ImageTitleToImagePlusConverter extends
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> T convert(final Object src, final Class<T> dest) {
+		if (!legacyEnabled()) throw new UnsupportedOperationException();
 		return src instanceof ImageTitle ? (T) ((ImageTitle) src).imp : null;
 	}
 

--- a/src/main/java/net/imagej/legacy/convert/OverlayToROITreeConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/OverlayToROITreeConverter.java
@@ -70,9 +70,11 @@ public class OverlayToROITreeConverter extends
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <T> T convert(Object src, Class<T> dest) {
-		if (!getInputType().isInstance(src)) throw new IllegalArgumentException(
-			"Unexpected source type: " + src.getClass());
+	public <T> T convert(final Object src, final Class<T> dest) {
+		if (!getInputType().isInstance(src)) {
+			throw new IllegalArgumentException("Unexpected source type: " + //
+				src.getClass());
+		}
 		if (!getOutputType().isAssignableFrom(dest))
 			throw new IllegalArgumentException("Unexpected output class: " + dest);
 

--- a/src/main/java/net/imagej/legacy/convert/ResultsTableToGenericTableConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/ResultsTableToGenericTableConverter.java
@@ -51,12 +51,14 @@ public class ResultsTableToGenericTableConverter extends
 {
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T> T convert(final Object src, final Class<T> dest) {
 		if (src == null || dest == null) throw new NullPointerException();
 		if (!(src instanceof ResultsTable)) return null;
 
-		return (T) new ResultsTableWrapper((ResultsTable) src);
+		final ResultsTableWrapper wrapper = new ResultsTableWrapper((ResultsTable) src);
+		@SuppressWarnings("unchecked")
+		final T typedWrapper = (T) wrapper;
+		return typedWrapper;
 	}
 
 	@Override


### PR DESCRIPTION
Hey guys,

related to the issue I posted on the forum:
https://forum.image.sc/t/imagej2-convert-imageplus-to-dataset/20728

For whatever reason (I really would like to know), the IJ1Helper is not set in the legacy service. The resulting NullPointerExceptions prevent me from working. That's why I'm suggesting this bugfix. If anybody has an idea when/why this IJ1Helper is not set, please let me know!

Cheers,
Rober