### PR TITLE
PlotService: add converter from Plot to ImagePlus and Img

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,11 +212,17 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
+			<artifactId>scijava-plot</artifactId>
+			<version>0.1.2-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.scijava</groupId>
 			<artifactId>scijava-ui-awt</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-ui-swing</artifactId>
+			<version>0.12.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>

--- a/src/main/java/net/imagej/legacy/convert/plot/PlotToImagePlusConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/plot/PlotToImagePlusConverter.java
@@ -1,0 +1,64 @@
+package net.imagej.legacy.convert.plot;
+
+import ij.ImagePlus;
+import org.scijava.plot.Plot;
+import org.scijava.Priority;
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.ConversionRequest;
+import org.scijava.convert.ConvertService;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+/**
+ * Converter plugin, that converts an {@link Plot} to {@link ImagePlus}.
+ *
+ * @author Matthias Arzt
+ * @see ConvertService
+ */
+@Plugin(type = Converter.class, priority = Priority.NORMAL_PRIORITY)
+public class PlotToImagePlusConverter extends AbstractConverter<Plot, ImagePlus> {
+
+	@Parameter
+	ConvertService convertService;
+
+	@Override
+	public boolean canConvert(ConversionRequest request) {
+		return request.destClass().isAssignableFrom( ImagePlus.class ) &&
+				Plot.class.isAssignableFrom( request.sourceClass() ) &&
+				convertService.supports(new ConversionRequest(
+						request.sourceObject(), request.sourceType(), BufferedImage.class));
+	}
+
+	@Override
+	public <T> T convert(Object o, Class<T> aClass) {
+		if(o instanceof Plot && ImagePlus.class.equals(aClass)) {
+			@SuppressWarnings("unchecked")
+			T t = (T) toImagePlus((Plot) o);
+			return t;
+		}
+		return null;
+	}
+
+	private ImagePlus toImagePlus(Plot plot) {
+		Image awtImage = convertService.convert(plot, BufferedImage.class);
+		//chart.draw(image.createGraphics(), new Rectangle2D.Float(0, 0, imp.getWidth(), imp.getHeight()));
+		//ImagePlus imp = IJ.createImage(plot.getTitle(), "RGB", plot.getPreferredWidth(), plot.getPreferredHeight(), 1);
+		//BufferedImage image = imp.getBufferedImage();
+		//imp.setImage(image);
+		return new ImagePlus( plot.getTitle(), awtImage );
+	}
+
+	@Override
+	public Class<ImagePlus> getOutputType() {
+		return ImagePlus.class;
+	}
+
+	@Override
+	public Class<Plot> getInputType() {
+		return Plot.class;
+	}
+}

--- a/src/main/java/net/imagej/legacy/convert/plot/PlotToImgConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/plot/PlotToImgConverter.java
@@ -1,0 +1,52 @@
+package net.imagej.legacy.convert.plot;
+
+import ij.ImagePlus;
+import org.scijava.plot.Plot;
+import net.imglib2.img.Img;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import org.scijava.Priority;
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.ConversionRequest;
+import org.scijava.convert.ConvertService;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * Converter plugin, that converts {@link Plot} to {@link Img}.
+ *
+ * @author Matthias Arzt
+ * @see ConvertService
+ */
+@Plugin(type = Converter.class, priority = Priority.NORMAL_PRIORITY)
+public class PlotToImgConverter extends AbstractConverter<Plot, Img> {
+
+	@Parameter
+	ConvertService convertService;
+
+	@Override
+	public boolean canConvert(ConversionRequest request) {
+		return request.destClass().isAssignableFrom( Img.class ) &&
+				Plot.class.isAssignableFrom(request.sourceClass()) &&
+				convertService.supports(new ConversionRequest(
+						request.sourceObject(), request.sourceType(), ImagePlus.class));
+	}
+
+	@Override
+	public <T> T convert(Object o, Class<T> aClass) {
+		ImagePlus imp = convertService.convert(o, ImagePlus.class);
+		@SuppressWarnings("unchecked")
+		T t = (T) ImageJFunctions.wrap(imp);
+		return t;
+	}
+
+	@Override
+	public Class<Img> getOutputType() {
+		return Img.class;
+	}
+
+	@Override
+	public Class<Plot> getInputType() {
+		return Plot.class;
+	}
+}

--- a/src/test/java/net/imagej/legacy/convert/plot/PlotToImageConverterTest.java
+++ b/src/test/java/net/imagej/legacy/convert/plot/PlotToImageConverterTest.java
@@ -1,0 +1,119 @@
+package net.imagej.legacy.convert.plot;
+
+import ij.ImagePlus;
+import org.scijava.plot.Plot;
+import org.scijava.plot.CategoryChart;
+import org.scijava.plot.PlotService;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.ARGBType;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.convert.ConvertService;
+
+import java.lang.reflect.Type;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link PlotToImgConverter} and {@link PlotToImagePlusConverter}
+ *
+ * @author Matthias Arzt
+ */
+public class PlotToImageConverterTest {
+
+	private final Context context = new Context(PlotService.class, ConvertService.class);
+
+	private final ConvertService convertService = context.service(ConvertService.class);
+
+	private final PlotService plotService = context.service(PlotService.class);
+
+	@Test
+	public void testCanConvertCategoryChartToImagePlus() {
+		testCanConvertCategoryChartTo(ImagePlus.class);
+	}
+
+	@Test
+	public void testCanConvertCategoryChartToImg() {
+		testCanConvertCategoryChartTo(Img.class);
+	}
+
+	@Test
+	public void testWontConvertCustomPlotToImagePlus() {
+		testWontConvertCustomPlotTo(ImagePlus.class);
+	}
+
+	@Test
+	public void testWontConvertCustomPlotToImg() {
+		testWontConvertCustomPlotTo(Img.class);
+	}
+
+	public void testCanConvertCategoryChartTo(Class<?> destClass) {
+		CategoryChart chart = plotService.newCategoryChart();
+		assertTrue(convertService.supports(chart, destClass));
+		assertTrue(convertService.supports(chart, (Type) destClass));
+	}
+
+	public void testWontConvertCustomPlotTo(Class<?> destClass) {
+		Plot ap = new CustomPlot();
+		assertFalse(convertService.supports(ap, destClass));
+		assertFalse(convertService.supports(ap, (Type) destClass));
+	}
+
+	@Test
+	public void testConversionToImagePlus() {
+		// setup
+		CategoryChart chart = plotService.newCategoryChart();
+		chart.setTitle("Hello World!");
+		chart.setPreferredSize(12,23);
+		// process
+		ImagePlus imp = convertService.convert(chart, ImagePlus.class);
+		// test
+		assertEquals(chart.getTitle(), imp.getTitle());
+		assertEquals(chart.getPreferredWidth(), imp.getWidth());
+		assertEquals(chart.getPreferredHeight(), imp.getHeight());
+	}
+
+	@Test
+	public void testConversionToImg() {
+		// setup
+		CategoryChart chart = plotService.newCategoryChart();
+		chart.setTitle("Hello World!");
+		chart.setPreferredSize(12,23);
+		// process
+		Img<ARGBType> img = convertService.convert(chart, Img.class);
+		// test
+		assertEquals(chart.getPreferredWidth(), img.dimension(0));
+		assertEquals(chart.getPreferredHeight(), img.dimension(1));
+	}
+
+	// -- Helper class --
+
+	class CustomPlot implements Plot {
+		@Override
+		public void setTitle(String title) {
+
+		}
+
+		@Override
+		public String getTitle() {
+			return null;
+		}
+
+		@Override
+		public void setPreferredSize(int width, int height) {
+
+		}
+
+		@Override
+		public int getPreferredWidth() {
+			return 0;
+		}
+
+		@Override
+		public int getPreferredHeight() {
+			return 0;
+		}
+	}
+}

--- a/src/test/java/net/imagej/legacy/convert/plot/PlotToImageDemo.java
+++ b/src/test/java/net/imagej/legacy/convert/plot/PlotToImageDemo.java
@@ -1,0 +1,61 @@
+package net.imagej.legacy.convert.plot;
+
+import ij.ImagePlus;
+import net.imglib2.img.Img;
+import net.imglib2.type.numeric.ARGBType;
+import org.scijava.Context;
+import org.scijava.convert.ConvertService;
+import org.scijava.plot.Plot;
+import org.scijava.plot.PlotService;
+import org.scijava.plot.XYPlot;
+import org.scijava.plot.XYSeries;
+import org.scijava.plugin.Parameter;
+import org.scijava.ui.UIService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Demonstrates how to convert an {@link Plot} to {@link Img} and {@link ImagePlus}.
+ *
+ * @author Matthias Arzt
+ */
+public class PlotToImageDemo {
+
+	@Parameter
+	PlotService plotService;
+
+	@Parameter
+	ConvertService convertService;
+
+	@Parameter
+	UIService uiService;
+
+	private void run() {
+		XYPlot plot = getXyPlot();
+
+		// convert to ImagePlus
+		ImagePlus imagePlus = convertService.convert(plot, ImagePlus.class);
+		uiService.show(imagePlus);
+
+		// convert to Img
+		Img<ARGBType> img = convertService.convert(plot, Img.class);
+		uiService.show(img);
+	}
+
+	private XYPlot getXyPlot() {
+		XYPlot plot = plotService.newXYPlot();
+		XYSeries series = plot.addXYSeries();
+		List<Double> xs = IntStream.rangeClosed(0, 100).mapToObj(x -> (double) x * 2. * Math.PI / 100.).collect(Collectors.toList());
+		List<Double> ys = xs.stream().map(Math::sin).collect(Collectors.toList());
+		series.setValues( xs, ys );
+		return plot;
+	}
+
+	public static void main(String... args) {
+		PlotToImageDemo demo = new PlotToImageDemo();
+		new Context().inject(demo);
+		demo.run();
+	}
+}


### PR DESCRIPTION
ImageJ users (that use the new PlotService) will want to convert plots to Img and ImagePlus.
The converters to enable this should be part of imagej-legacy, as the conversion depends on ImagePlus.

This PR depends on https://github.com/scijava/scijava-ui-swing/pull/43