### PR TITLE
add an extensible plugin-service for filling the auto-complete list in IJ macro

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -59,6 +59,7 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 	ToolTipSupplier
 {
 	private ModuleService moduleService;
+	private MacroExtensionAutoCompletionService macroExtensionAutoCompletionService;
 
 	private static MacroAutoCompletionProvider instance = null;
 
@@ -69,6 +70,8 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 			parseFunctionsHtmlDoc("/doc/ij1macro/functions.html");
 		}
 		parseFunctionsHtmlDoc("/doc/ij1macro/functions_extd.html");
+
+
 	}
 
 	public static synchronized MacroAutoCompletionProvider getInstance() {
@@ -242,6 +245,18 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 
 				addCompletion(makeListEntry(this, headline, null, description));
 			}
+		}
+	}
+
+	public void addMacroExtensionAutoCompletions(MacroExtensionAutoCompletionService macroExtensionAutoCompletionService) {
+		if (this.macroExtensionAutoCompletionService != null) {
+			return;
+		}
+		this.macroExtensionAutoCompletionService = macroExtensionAutoCompletionService;
+
+		List<BasicCompletion> completions = macroExtensionAutoCompletionService.getCompletions(this);
+		for (BasicCompletion completion : completions) {
+			addCompletion(completion);
 		}
 	}
 }

--- a/src/main/java/net/imagej/legacy/plugin/MacroExtensionAutoCompletionPlugin.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroExtensionAutoCompletionPlugin.java
@@ -1,0 +1,21 @@
+package net.imagej.legacy.plugin;
+
+import org.fife.ui.autocomplete.BasicCompletion;
+import org.fife.ui.autocomplete.CompletionProvider;
+import org.scijava.plugin.SciJavaPlugin;
+
+import java.util.List;
+
+/**
+ * MacroExtensionAutoCompletionPlugin
+ *
+ * This interface must be implemented in order to extend the auto completion list of the Script editor.
+ * Furthermore, the implementing class must be annotated with @Plugin(type = MacroExtensionAutoCompletionPlugin.class).
+ *
+ * Author: @haesleinhuepf
+ * December 2018
+ */
+
+public interface MacroExtensionAutoCompletionPlugin  extends SciJavaPlugin {
+    List<BasicCompletion> getCompletions(CompletionProvider completionProvider);
+}

--- a/src/main/java/net/imagej/legacy/plugin/MacroExtensionAutoCompletionService.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroExtensionAutoCompletionService.java
@@ -1,0 +1,59 @@
+package net.imagej.legacy.plugin;
+
+import net.imagej.ImageJService;
+import org.fife.ui.autocomplete.BasicCompletion;
+import org.fife.ui.autocomplete.CompletionProvider;
+import org.scijava.plugin.AbstractPTService;
+import org.scijava.plugin.Plugin;
+import org.scijava.plugin.PluginInfo;
+import org.scijava.service.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * MacroExtensionAutoCompletionService
+ *
+ * This service manages extensions to the auto-complete pull down of the script editor.
+ *
+ * Author: @haesleinhuepf
+ * December 2018
+ */
+
+
+@Plugin(type = Service.class)
+public class MacroExtensionAutoCompletionService  extends AbstractPTService<MacroExtensionAutoCompletionPlugin> implements ImageJService {
+
+    private HashMap<String, PluginInfo<MacroExtensionAutoCompletionPlugin>> macroExtensionAutoCompletionPlugins = new HashMap<>();
+
+    @Override
+    public void initialize() {
+        for (final PluginInfo<MacroExtensionAutoCompletionPlugin> info : getPlugins()) {
+            String name = info.getName();
+            if (name == null || name.isEmpty()) {
+                name = info.getClassName();
+            }
+            macroExtensionAutoCompletionPlugins.put(name, info);
+        }
+    }
+
+    public List<BasicCompletion> getCompletions(CompletionProvider completionProvider) {
+        ArrayList<BasicCompletion> completions = new ArrayList<BasicCompletion>();
+        System.out.println("Completions search");
+        for (String key : macroExtensionAutoCompletionPlugins.keySet()) {
+            System.out.println("macroext " + key);
+            PluginInfo<MacroExtensionAutoCompletionPlugin> info = macroExtensionAutoCompletionPlugins.get(key);
+
+            List<BasicCompletion> list = pluginService().createInstance(info).getCompletions(completionProvider);
+            completions.addAll(list);
+
+        }
+        return completions;
+    }
+
+    @Override
+    public Class<MacroExtensionAutoCompletionPlugin> getPluginType() {
+        return MacroExtensionAutoCompletionPlugin.class;
+    }
+}

--- a/src/main/java/net/imagej/legacy/plugin/MacroLanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroLanguageSupportPlugin.java
@@ -62,6 +62,9 @@ public class MacroLanguageSupportPlugin extends AbstractLanguageSupport
 	@Parameter
 	ModuleService moduleService;
 
+	@Parameter
+	MacroExtensionAutoCompletionService macroExtensionAutoCompletionService;
+
 	private final static int MINIMUM_WORD_LENGTH_TO_OPEN_PULLDOWN = 1;
 
 	@Override
@@ -93,6 +96,7 @@ public class MacroLanguageSupportPlugin extends AbstractLanguageSupport
 		MacroAutoCompletionProvider provider = MacroAutoCompletionProvider
 				.getInstance();
 		provider.addModuleCompletions(moduleService);
+		provider.addMacroExtensionAutoCompletions(macroExtensionAutoCompletionService);
 
 		return provider;
 	}


### PR DESCRIPTION
Dear all,

with this change, the auto-completion pulldown in IJ macro becomes extensible using SciJavas Plugin/Service mechanism. This is necessary in order to support auto-completions for Macro Extensions.
![image](https://user-images.githubusercontent.com/12660498/50376338-2a443c80-060c-11e9-897e-c8cf8a9d92b2.png)

FYI: An example implementation of a compatible plugin can be found here:
https://github.com/haesleinhuepf/clearclij/blob/add_auto_completion_for_ij_macro/src/main/java/net/haesleinhuepf/imagej/macro/CLIJMacroExtensionAutoCompletionPlugin.java

Let me know if anything speaks against merging this or if you see potential for improvement.

Merry Christmas!

Cheers,
Robert
