### PR TITLE
make the MacroExtensionAutoCompletionService initialize the lazy way

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/MacroExtensionAutoCompletionService.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroExtensionAutoCompletionService.java
@@ -27,8 +27,12 @@ public class MacroExtensionAutoCompletionService  extends AbstractPTService<Macr
 
     private HashMap<String, PluginInfo<MacroExtensionAutoCompletionPlugin>> macroExtensionAutoCompletionPlugins = new HashMap<>();
 
-    @Override
-    public void initialize() {
+    boolean initialized = false;
+
+    private void initializeService() {
+        if (initialized) {
+            return;
+        }
         for (final PluginInfo<MacroExtensionAutoCompletionPlugin> info : getPlugins()) {
             String name = info.getName();
             if (name == null || name.isEmpty()) {
@@ -36,9 +40,11 @@ public class MacroExtensionAutoCompletionService  extends AbstractPTService<Macr
             }
             macroExtensionAutoCompletionPlugins.put(name, info);
         }
+        initialized = true;
     }
 
     public List<BasicCompletion> getCompletions(CompletionProvider completionProvider) {
+        initializeService();
         ArrayList<BasicCompletion> completions = new ArrayList<BasicCompletion>();
         System.out.println("Completions search");
         for (String key : macroExtensionAutoCompletionPlugins.keySet()) {


### PR DESCRIPTION
Hey @ctrueden ,

here you go: Lazy initialization of the service. I see the point of making context initialization as fast as possible and thus, initialize services as this the lazy way. I was just wondering, if the initialize method is non-final and thus can be overridden, what would be a good scenario, where you have to initialize a service with it?

Thanks!

Cheers,
Robert
