### PR TITLE
Extend auto completion pulldown

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -143,6 +143,45 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 		return true;
 	}
 
+	void addModuleCompletions(ModuleService moduleService) {
+		if (this.moduleService == moduleService) {
+			return;
+		}
+		sorted = false;
+		this.moduleService = moduleService;
+
+		for (ModuleInfo info : moduleService.getModules()) {
+			if(info.getMenuPath().getLeaf() != null) {
+				String name = info.getMenuPath().getLeaf().getName().trim();
+				String headline = "run(\"" + name +"\")";
+				String description = "<b>" + headline + "</b><p>" +
+						"<a href=\"https://imagej.net/Special:Search/" + name.replace(" ", "%20") + "\">Search imagej wiki for help</a>";
+
+				addCompletion(makeListEntry(this, headline, null, description));
+			}
+		}
+	}
+
+	public void addMacroExtensionAutoCompletions(MacroExtensionAutoCompletionService macroExtensionAutoCompletionService) {
+		if (this.macroExtensionAutoCompletionService != null) {
+			return;
+		}
+		sorted = false;
+		this.macroExtensionAutoCompletionService = macroExtensionAutoCompletionService;
+
+		List<BasicCompletion> completions = macroExtensionAutoCompletionService.getCompletions(this);
+		for (BasicCompletion completion : completions) {
+			addCompletion(completion);
+		}
+	}
+
+	public void sort() {
+		if (!sorted) {
+			Collections.sort(completions, new SortByRelevanceComparator());
+			sorted = true;
+		}
+	}
+	
 	private boolean checkCompletion(final String headline, final String name, final String description) {
 		return headline.length() > 0 && //
 			name.length() > 1 && //
@@ -232,24 +271,7 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 		return Character.isLetterOrDigit(ch) || ch == '_' || ch == '.' || ch == '"';
 	}
 
-	void addModuleCompletions(ModuleService moduleService) {
-		if (this.moduleService == moduleService) {
-			return;
-		}
-		sorted = false;
-		this.moduleService = moduleService;
 
-		for (ModuleInfo info : moduleService.getModules()) {
-			if(info.getMenuPath().getLeaf() != null) {
-				String name = info.getMenuPath().getLeaf().getName().trim();
-				String headline = "run(\"" + name +"\")";
-				String description = "<b>" + headline + "</b><p>" +
-						"<a href=\"https://imagej.net/Special:Search/" + name.replace(" ", "%20") + "\">Search imagej wiki for help</a>";
-
-				addCompletion(makeListEntry(this, headline, null, description));
-			}
-		}
-	}
 
 	/**
 	 * Returns a list of <tt>Completion</tt>s in this provider with the
@@ -307,23 +329,4 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 		return completions;
 	}
 
-	public void addMacroExtensionAutoCompletions(MacroExtensionAutoCompletionService macroExtensionAutoCompletionService) {
-		if (this.macroExtensionAutoCompletionService != null) {
-			return;
-		}
-		sorted = false;
-		this.macroExtensionAutoCompletionService = macroExtensionAutoCompletionService;
-
-		List<BasicCompletion> completions = macroExtensionAutoCompletionService.getCompletions(this);
-		for (BasicCompletion completion : completions) {
-			addCompletion(completion);
-		}
-	}
-
-	public void sort() {
-		if (!sorted) {
-			Collections.sort(completions, new SortByRelevanceComparator());
-			sorted = true;
-		}
-	}
 }

--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -225,7 +225,7 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 	}
 
 	protected boolean isValidChar(char ch) {
-		return Character.isLetterOrDigit(ch) || ch == '_' || ch == '.' || ch == '"' || ch == '(';
+		return Character.isLetterOrDigit(ch) || ch == '_' || ch == '.' || ch == '"';
 	}
 
 	void addModuleCompletions(ModuleService moduleService) {

--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -45,6 +45,7 @@ import java.util.List;
 import org.fife.ui.autocomplete.BasicCompletion;
 import org.fife.ui.autocomplete.Completion;
 import org.fife.ui.autocomplete.DefaultCompletionProvider;
+import org.fife.ui.autocomplete.SortByRelevanceComparator;
 import org.fife.ui.rtextarea.RTextArea;
 import org.fife.ui.rtextarea.ToolTipSupplier;
 
@@ -67,6 +68,8 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 
 	private static MacroAutoCompletionProvider instance = null;
 
+	private boolean sorted = false;
+
 	private MacroAutoCompletionProvider() {
 		parseFunctionsHtmlDoc("/doc/ij1macro/functions.html");
 		parseFunctionsHtmlDoc("/doc/ij1macro/functions_extd.html");
@@ -82,6 +85,7 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 	private boolean parseFunctionsHtmlDoc(final String filename) {
 		InputStream resourceAsStream;
 
+		sorted = false;
 		try {
 			if (filename.startsWith("http")) {
 				final URL url = new URL(filename);
@@ -232,6 +236,7 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 		if (this.moduleService == moduleService) {
 			return;
 		}
+		sorted = false;
 		this.moduleService = moduleService;
 
 		for (ModuleInfo info : moduleService.getModules()) {
@@ -267,7 +272,9 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 			String text = completion.getInputText().toLowerCase();
 			if (text.contains(inputText)) {
 				if (text.startsWith(inputText)) {
+					System.out.println("add at beginning");
 					result.add(count, completion);
+					count++;
 				} else {
 					result.add(completion);
 				}
@@ -294,15 +301,29 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 		return retVal;
 	}
 
+	@Override
+	public List<Completion> getCompletions(JTextComponent comp) {
+		List<Completion> completions = this.getCompletionsImpl(comp);
+		return completions;
+	}
+
 	public void addMacroExtensionAutoCompletions(MacroExtensionAutoCompletionService macroExtensionAutoCompletionService) {
 		if (this.macroExtensionAutoCompletionService != null) {
 			return;
 		}
+		sorted = false;
 		this.macroExtensionAutoCompletionService = macroExtensionAutoCompletionService;
 
 		List<BasicCompletion> completions = macroExtensionAutoCompletionService.getCompletions(this);
 		for (BasicCompletion completion : completions) {
 			addCompletion(completion);
+		}
+	}
+
+	public void sort() {
+		if (!sorted) {
+			Collections.sort(completions, new SortByRelevanceComparator());
+			sorted = true;
 		}
 	}
 }

--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -38,6 +38,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.fife.ui.autocomplete.BasicCompletion;
@@ -48,6 +50,8 @@ import org.fife.ui.rtextarea.ToolTipSupplier;
 
 import org.scijava.module.ModuleInfo;
 import org.scijava.module.ModuleService;
+
+import javax.swing.text.JTextComponent;
 
 /**
  * Creates the list of auto-completion suggestions from functions.html
@@ -240,6 +244,52 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 				addCompletion(makeListEntry(this, headline, null, description));
 			}
 		}
+	}
+
+	/**
+	 * Returns a list of <tt>Completion</tt>s in this provider with the
+	 * specified input text.
+	 *
+	 * @param inputText The input text to search for.
+	 * @return A list of {@link Completion}s, or <code>null</code> if there
+	 *         are no matching <tt>Completion</tt>s.
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	public List<Completion> getCompletionByInputText(String inputText) {
+		System.out.println("Searching for " + inputText);
+		ArrayList<Completion> result = new ArrayList<Completion>();
+
+		int count = 0;
+		for (Completion completion : completions) {
+			String text = completion.getInputText();
+			if (text.contains(inputText)) {
+				if (text.startsWith(inputText)) {
+					result.add(count, completion);
+				} else {
+					result.add(completion);
+				}
+			}
+		}
+
+		return result;
+	}
+
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	protected List<Completion> getCompletionsImpl(JTextComponent comp) {
+
+		List<Completion> retVal = new ArrayList<Completion>();
+		String text = getAlreadyEnteredText(comp);
+
+		if (text != null) {
+			retVal = getCompletionByInputText(text);
+		}
+		return retVal;
 	}
 
 	public void addMacroExtensionAutoCompletions(MacroExtensionAutoCompletionService macroExtensionAutoCompletionService) {

--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -257,12 +257,14 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<Completion> getCompletionByInputText(String inputText) {
-		System.out.println("Searching for " + inputText);
+
+		inputText = inputText.toLowerCase();
+
 		ArrayList<Completion> result = new ArrayList<Completion>();
 
 		int count = 0;
 		for (Completion completion : completions) {
-			String text = completion.getInputText();
+			String text = completion.getInputText().toLowerCase();
 			if (text.contains(inputText)) {
 				if (text.startsWith(inputText)) {
 					result.add(count, completion);

--- a/src/main/java/net/imagej/legacy/plugin/MacroLanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroLanguageSupportPlugin.java
@@ -34,11 +34,14 @@ package net.imagej.legacy.plugin;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.SwingUtilities;
+import javax.swing.text.JTextComponent;
 
 import org.fife.rsta.ac.AbstractLanguageSupport;
 import org.fife.ui.autocomplete.AutoCompletion;
+import org.fife.ui.autocomplete.Completion;
 import org.fife.ui.autocomplete.CompletionProvider;
 import org.fife.ui.autocomplete.LanguageAwareCompletionProvider;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
@@ -88,8 +91,21 @@ public class MacroLanguageSupportPlugin extends AbstractLanguageSupport
 	}
 
 	private CompletionProvider getCompletionProvider() {
-		CompletionProvider provider = new LanguageAwareCompletionProvider(getMacroAutoCompletionProvider());
+		CompletionProvider provider = new CustomLanguageAwareCompletionProvider(getMacroAutoCompletionProvider());
 		return provider;
+	}
+
+	// this class is necessary to prevent the language aware provider to sort the result list; we have our own sorting
+	private class CustomLanguageAwareCompletionProvider extends LanguageAwareCompletionProvider{
+		public CustomLanguageAwareCompletionProvider(CompletionProvider provider){
+			super(provider);
+		}
+
+		@Override
+		public List<Completion> getCompletions(JTextComponent comp) {
+			List<Completion> completions = this.getCompletionsImpl(comp);
+			return completions;
+		}
 	}
 
 	private MacroAutoCompletionProvider getMacroAutoCompletionProvider() {
@@ -97,7 +113,7 @@ public class MacroLanguageSupportPlugin extends AbstractLanguageSupport
 				.getInstance();
 		provider.addModuleCompletions(moduleService);
 		provider.addMacroExtensionAutoCompletions(macroExtensionAutoCompletionService);
-
+		provider.sort();
 		return provider;
 	}
 

--- a/src/main/java/net/imagej/legacy/plugin/MacroLanguageSupportPlugin.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroLanguageSupportPlugin.java
@@ -154,8 +154,13 @@ public class MacroLanguageSupportPlugin extends AbstractLanguageSupport
 						// the pulldown should not be hidden if CTRL+SPACE are pressed
 						ac.hideChildWindows();
 					}
-				}
-				else if (e.getKeyCode() >= 65 // a
+				} else if ((e.isControlDown() && e.getKeyCode() != KeyEvent.VK_SPACE) || // control pressed but not space
+					e.getKeyCode() == KeyEvent.VK_LEFT || // arrow keys left/right were pressed
+					e.getKeyCode() == KeyEvent.VK_RIGHT
+				) {
+					System.out.println("cloooose");
+					ac.hideChildWindows();
+				} else if (e.getKeyCode() >= 65 // a
 				&& e.getKeyCode() <= 90 // z
 				) {
 					if (MacroAutoCompletionProvider.getInstance().getAlreadyEnteredText(


### PR DESCRIPTION
Dear *,

with this change, the auto-completion pulldown contains no longer just the entries which start with the search string. Also words containing the search string are listed. This allows entering `bit` and getting the suggestion `run("8-bit")`.

![image](https://user-images.githubusercontent.com/12660498/53196822-3606ac00-3619-11e9-8c8b-714a57dca912.png)

I guess that's usefull, but if somebody could please test it, before we distribute it to everyone, that would be great. I would like to ensure that it's not confusing. I'll also create a forum post regarding the test-request.

Thanks!

Cheers,
Robert