### PR TITLE
Pack ImageJ1 frame before restoring its location

### DIFF
--- a/src/main/java/net/imagej/legacy/IJ1Helper.java
+++ b/src/main/java/net/imagej/legacy/IJ1Helper.java
@@ -220,6 +220,7 @@ public class IJ1Helper extends AbstractContextual {
 			// the time the IJ1Helper is initialized. Ideally we would like to handle
 			// positioning via the LegacyUI though, so that we can restore positions
 			// on secondary monitors and such.
+			ij1.pack();
 			ij1.setLocation(ij1.getPreferredLocation());
 		}
 	}


### PR DESCRIPTION
On the Mac, this prevents an upwards drift of the restored location. Before, the main ImageJ window was restored higher (exactly the size of the title bar) upon launch than its preferred (i.e. previous) location.