### PR TITLE
Add miglayout-swing and pin to version 5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,8 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+
+		<miglayout-swing.version>5.2</miglayout-swing.version>
 	</properties>
 
 	<repositories>
@@ -237,6 +239,12 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-search</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.miglayout</groupId>
+					<artifactId>miglayout</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
@@ -245,14 +253,32 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-ui-awt</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.miglayout</groupId>
+					<artifactId>miglayout</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>scijava-ui-swing</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.miglayout</groupId>
+					<artifactId>miglayout</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>script-editor</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.miglayout</groupId>
+					<artifactId>miglayout</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Third party dependencies -->
@@ -260,6 +286,12 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.miglayout</groupId>
+			<artifactId>miglayout-swing</artifactId>
+			<version>${miglayout-swing.version}</version>
+		</dependency>
+		
 
 		<!-- Test dependencies -->
 		<dependency>


### PR DESCRIPTION
This is used in `SearchBarHacker`, but wasn't declared explicitly so far.

Until `miglayout-swing` is used across the SciJava software stack, we need to exclude miglayout from other dependencies.

* The exclusions can be removed once https://github.com/scijava/scijava-ui-awt/pull/1, https://github.com/scijava/scijava-ui-swing/pull/46, https://github.com/scijava/script-editor/pull/40, and https://github.com/scijava/scijava-search/pull/17 are all merged and released.
* The version pinning can be removed once we have a `pom-scijava` release managing this version (see https://github.com/scijava/pom-scijava/pull/97).