### PR TITLE
Improve ImageJ 1.x plugin discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.imagej</groupId>
 	<artifactId>imagej-legacy</artifactId>
-	<version>0.36.1-SNAPSHOT</version>
+	<version>0.37.0-SNAPSHOT</version>
 
 	<name>ImageJ Legacy Bridge</name>
 	<description>The legacy component enables backward compatibility with the legacy version of ImageJ (1.x). It contains the code necessary to translate ImageJ images into ImageJ1 format and back, so that legacy plugins can be executed faithfully.</description>

--- a/src/main/java/net/imagej/legacy/IJ1Helper.java
+++ b/src/main/java/net/imagej/legacy/IJ1Helper.java
@@ -791,6 +791,44 @@ public class IJ1Helper extends AbstractContextual {
 		return Menus.getCommands();
 	}
 
+	private Method getMenuMethod;
+	private Field nPluginsField;
+	private Method addItemMethod;
+
+	public void addCommand(final String menuPath, final String label, final String command) {
+		// Register the command in the table.
+		final Hashtable<String, String> commands = getCommands();
+		if (commands.containsKey(label)) return;
+		commands.put(label, command);
+
+		// Try to add the command to the menu bar.
+		try {
+			if (getMenuMethod == null) {
+				getMenuMethod = Menus.class.getDeclaredMethod("getMenu", String.class);
+				getMenuMethod.setAccessible(true);
+			}
+			if (nPluginsField == null) {
+				nPluginsField = Menus.class.getDeclaredField("nPlugins");
+				nPluginsField.setAccessible(true);
+			}
+			if (addItemMethod == null) {
+				addItemMethod = Menus.class.getDeclaredMethod("addItem", Menu.class,
+					String.class, int.class, boolean.class);
+				addItemMethod.setAccessible(true);
+			}
+			final Object menu = getMenuMethod.invoke(null, menuPath);
+			final int nPlugins = (int) nPluginsField.get(null);
+			nPluginsField.set(null, nPlugins + 1);
+			if (menu != null) addItemMethod.invoke(null, menu, label, 0, false);
+		}
+		catch (final NoSuchMethodException | NoSuchFieldException
+				| SecurityException | IllegalAccessException | IllegalArgumentException
+				| InvocationTargetException exc)
+		{
+			log.error(exc);
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	public Hashtable<Integer, String> getShortcuts() {
 		return Menus.getShortcuts();


### PR DESCRIPTION
Now, when ImageJ1 plugins are present on the system classpath, they will be noticed and parsed, even when there is no local ImageJ installation, and therefore no existing plugins folder.

Among other scenarios, this improves behavior of `jgo sc.fiji:fiji`, and addresses issues such as imagej/pyimagej#36.

Could anyone interested please test? (? @imagejan @haesleinhuepf @frauzufall @hadim @jluethi ?)

You can checkout this PR and build it (`git clone -b plugins-on-classpath git://github.com/imagej/imagej-legacy; cd imagej-legacy; mvn clean install`). If you want to use pyimagej or jgo, just mix in the custom artifact to your endpoint e.g. `sc.fiji:fiji+net.imagej:imagej-legacy:0.37.0-SNAPSHOT`. (If you want to be 100% certain you're mixing in the right artifact, you can change the version to something known to be unique like `999-SNAPSHOT` first before running `mvn clean install`; and then reference it as such.)