### PR TITLE
Bugfix freeze on Linux

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -153,7 +153,7 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 		sorted = false;
 		this.moduleService = moduleService;
 
-		ArrayList<Completion> list = new ArrayList<Completion>();
+		ArrayList<Completion> completions = new ArrayList<>();
 
 		for (ModuleInfo info : moduleService.getModules()) {
 			if(info.getMenuPath().getLeaf() != null) {

--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -153,6 +153,8 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 		sorted = false;
 		this.moduleService = moduleService;
 
+		ArrayList<Completion> list = new ArrayList<Completion>();
+
 		for (ModuleInfo info : moduleService.getModules()) {
 			if(info.getMenuPath().getLeaf() != null) {
 				String name = info.getMenuPath().getLeaf().getName().trim();
@@ -160,9 +162,10 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 				String description = "<b>" + headline + "</b><p>" +
 						"<a href=\"https://imagej.net/Special:Search/" + name.replace(" ", "%20") + "\">Search imagej wiki for help</a>";
 
-				addCompletion(makeListEntry(this, headline, null, description));
+				list.add(makeListEntry(this, headline, null, description));
 			}
 		}
+		addCompletions(list);
 	}
 
 	public void addMacroExtensionAutoCompletions(MacroExtensionAutoCompletionService macroExtensionAutoCompletionService) {
@@ -173,9 +176,12 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 		this.macroExtensionAutoCompletionService = macroExtensionAutoCompletionService;
 
 		List<BasicCompletion> completions = macroExtensionAutoCompletionService.getCompletions(this);
+		List<Completion> completionsCopy = new ArrayList<Completion>();
 		for (BasicCompletion completion : completions) {
-			addCompletion(completion);
+			completionsCopy.add(completion);
 		}
+		addCompletions(completionsCopy);
+
 	}
 
 	public void sort() {

--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -176,7 +176,7 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 		this.macroExtensionAutoCompletionService = macroExtensionAutoCompletionService;
 
 		List<BasicCompletion> completions = macroExtensionAutoCompletionService.getCompletions(this);
-		List<Completion> completionsCopy = new ArrayList<Completion>();
+		List<Completion> completionsCopy = new ArrayList<>();
 		for (BasicCompletion completion : completions) {
 			completionsCopy.add(completion);
 		}

--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -165,7 +165,7 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 				completions.add(makeListEntry(this, headline, null, description));
 			}
 		}
-		addCompletions(list);
+		addCompletions(completions);
 	}
 
 	public void addMacroExtensionAutoCompletions(MacroExtensionAutoCompletionService macroExtensionAutoCompletionService) {

--- a/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroAutoCompletionProvider.java
@@ -162,7 +162,7 @@ class MacroAutoCompletionProvider extends DefaultCompletionProvider implements
 				String description = "<b>" + headline + "</b><p>" +
 						"<a href=\"https://imagej.net/Special:Search/" + name.replace(" ", "%20") + "\">Search imagej wiki for help</a>";
 
-				list.add(makeListEntry(this, headline, null, description));
+				completions.add(makeListEntry(this, headline, null, description));
 			}
 		}
 		addCompletions(list);


### PR DESCRIPTION
Hi everyone,

here comes a bugfixe related to https://github.com/imagej/imagej-legacy/issues/227

Instead of submitting individual completions to the AutoComplete (upstream dependency), we send a list of completions. This prevents the list of completions being sorted again and again. The issue appeared on some Linux/MacOS computers not very reproducibly. However, on @frauzufall laptop we were able to reproduce it and fix it.

Let me know if you see any issue. I would otherwise merge in 7 days.

Cheers,
Robert