### PR TITLE
MacroRecorder: Improve handling of org.scijava.widget.Button

### DIFF
--- a/src/main/java/net/imagej/legacy/convert/StringToButtonConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/StringToButtonConverter.java
@@ -1,0 +1,31 @@
+package net.imagej.legacy.convert;
+
+import org.scijava.Priority;
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.ConversionRequest;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Plugin;
+import org.scijava.widget.Button;
+
+@Plugin(type = Converter.class, priority = Priority.LOW)
+public class StringToButtonConverter extends AbstractConverter<String, Button> {
+	@Override
+	public <T> T convert(Object src, Class<T> dest) {
+		return null;
+	}
+
+	@Override
+	public Class<Button> getOutputType() {
+		return Button.class;
+	}
+
+	@Override
+	public Class<String> getInputType() {
+		return String.class;
+	}
+
+	@Override
+	public boolean supports(ConversionRequest request) {
+		return super.supports(request);
+	}
+}

--- a/src/main/java/net/imagej/legacy/plugin/MacroRecorderPostprocessor.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroRecorderPostprocessor.java
@@ -42,6 +42,7 @@ import org.scijava.module.process.AbstractPostprocessorPlugin;
 import org.scijava.module.process.PostprocessorPlugin;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.widget.Button;
 import org.scijava.widget.TextWidget;
 
 /**
@@ -73,11 +74,16 @@ public class MacroRecorderPostprocessor extends AbstractPostprocessorPlugin {
 			final String name = input.getName();
 			if (excludedInputs != null && excludedInputs.contains(name)) continue;
 			if (excludedFromRecording(input)) continue;
+			if (isButton(input)) ij1Helper.recordOption(name, "0");
 			final Object value = module.getInput(name);
 			if (value != null) ij1Helper.recordOption(name, toString(value));
 		}
 
 		ij1Helper.finishRecording();
+	}
+
+	private boolean isButton(ModuleItem<?> input) {
+		return input.getType().equals(Button.class);
 	}
 
 	// -- Helper methods --

--- a/src/test/java/net/imagej/legacy/ExploreCommandRecording.java
+++ b/src/test/java/net/imagej/legacy/ExploreCommandRecording.java
@@ -1,0 +1,37 @@
+package net.imagej.legacy;
+
+import ij.plugin.frame.Recorder;
+import org.scijava.command.Command;
+import org.scijava.command.DefaultCommandService;
+import org.scijava.plugin.Parameter;
+import org.scijava.widget.Button;
+
+public class ExploreCommandRecording implements Command
+{
+	@Parameter
+	String string = "Hello";
+
+	@Parameter( callback = "callback" )
+	Button button;
+
+	@Override
+	public void run()
+	{
+
+	}
+
+	public void callback()
+	{
+		System.out.println("Button pressed.");
+	}
+
+	public static void main( String[] args )
+	{
+		// turn on recorder
+		new Recorder();
+
+		// execute above command (does not work)
+		final DefaultCommandService cs = new DefaultCommandService();
+		cs.run( ExploreCommandRecording.class, true );
+	}
+}


### PR DESCRIPTION
* button in scijava command will be recorded as `buttonName=0`
* macro call with `buttonName=0` will not display widget with button

Should fix https://forum.image.sc/t/scijava-command-macro-recording/35056

Would be nice to add a test, not sure how this would be done and I don't have more time, happy for pointers! :)