### PR TITLE
Improves IJ1 Macro Recording by using objectService.getName method instead of toString

### DIFF
--- a/src/main/java/net/imagej/legacy/IJ1Helper.java
+++ b/src/main/java/net/imagej/legacy/IJ1Helper.java
@@ -93,6 +93,7 @@ import org.scijava.MenuPath;
 import org.scijava.event.EventHandler;
 import org.scijava.log.LogService;
 import org.scijava.module.ModuleInfo;
+import org.scijava.object.ObjectService;
 import org.scijava.platform.event.AppAboutEvent;
 import org.scijava.platform.event.AppOpenFilesEvent;
 import org.scijava.platform.event.AppPreferencesEvent;
@@ -123,6 +124,10 @@ public class IJ1Helper extends AbstractContextual {
 
 	@Parameter
 	private LogService log;
+
+	/** A reference to ObjectService in order to get the name of Object in the ObjectService */
+	@Parameter
+	private ObjectService objectService;
 
 	/** Search bar in the main window. */
 	private Object searchBar;
@@ -647,6 +652,12 @@ public class IJ1Helper extends AbstractContextual {
 	/** Returns true if the class is assignable to {@link ImagePlus}. */
 	public boolean isImagePlus(final Class<?> c) {
 		return ImagePlus.class.isAssignableFrom(c);
+	}
+
+	/** Returns the name of the object in the object service
+	 * - return non null even if the object is not in the object service */
+	public String getObjectName(final Object o) {
+		return objectService.getName(o);
 	}
 
 	/**

--- a/src/main/java/net/imagej/legacy/plugin/IJ1MacroEngine.java
+++ b/src/main/java/net/imagej/legacy/plugin/IJ1MacroEngine.java
@@ -248,7 +248,7 @@ public class IJ1MacroEngine extends AbstractScriptEngine {
 			return v.toString();
 		}
 		else {
-			return "\"" + quote(v.toString()) + "\"";
+			return "\"" + quote(ij1Helper.getObjectName(v)) + "\"";
 		}
 	}
 

--- a/src/main/java/net/imagej/legacy/plugin/MacroRecorderPostprocessor.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroRecorderPostprocessor.java
@@ -40,6 +40,7 @@ import org.scijava.module.Module;
 import org.scijava.module.ModuleItem;
 import org.scijava.module.process.AbstractPostprocessorPlugin;
 import org.scijava.module.process.PostprocessorPlugin;
+import org.scijava.object.ObjectService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.widget.TextWidget;
@@ -55,6 +56,9 @@ public class MacroRecorderPostprocessor extends AbstractPostprocessorPlugin {
 
 	@Parameter(required = false)
 	private LegacyService legacyService;
+
+	@Parameter(required = false)
+	private ObjectService objectService;
 
 	// -- ModuleProcessor methods --
 
@@ -104,7 +108,7 @@ public class MacroRecorderPostprocessor extends AbstractPostprocessorPlugin {
 		final String title = IJ1Helper.getTitle(value);
 		if (title != null) return title;
 
-		return value.toString();
+		return objectService.getName(value);
 	}
 
 }

--- a/src/test/java/net/imagej/legacy/plugin/IJ1MacroLanguageNamedObjectTest.java
+++ b/src/test/java/net/imagej/legacy/plugin/IJ1MacroLanguageNamedObjectTest.java
@@ -77,45 +77,6 @@ public class IJ1MacroLanguageNamedObjectTest {
 	}
 
 	@Test
-	public void testGroovyNamedObject() throws InterruptedException,
-			ExecutionException
-	{
-		// TODO : Do we want this behaviour with groovy ? But do we have a choice ?
-		// Puts a named Pet object into the ObjectService
-		Pet pet = new Pet("Felix", "Cat");
-		objectService.addObject(pet,pet.getName());
-
-		// Makes Pet class easily discoverable be the script service
-		scriptService.addAlias(Pet.class);
-
-		// Execute a script.
-		final String script = "" + //
-				"#@ Pet animal\n" + //
-				"#@ ObjectService objectService\n" + //
-				"#@output String greeting\n" + //
-				"greeting = 'Oh, '+objectService.getName(animal)+' is so cute!'\n" + //
-				"";
-
-		final ScriptModule m = scriptService.run("greet.groovy", script, true, //
-				"animal", "Felix").get(); // Felix is given -> needs String to Pet conversion
-
-		final Object returnValue = m.getReturnValue();
-
-		// Verify that the input has been found - felix the cat
-		// Correct class
-		assertSame(m.getInput("animal").getClass(), Pet.class);
-		// Correct instance
-		assertSame(m.getInput("animal"), pet);
-
-		// Verify that the script executed correctly - with the correct object being
-		// given to the script (groovy behaviour)
-		assertEquals("Oh, Felix is so cute!", //
-				m.getOutput("greeting"));
-
-	}
-
-
-	@Test
 	public void testIJ1MacroLanguageNamedObject() throws InterruptedException,
 			ExecutionException
 	{

--- a/src/test/java/net/imagej/legacy/plugin/IJ1MacroLanguageNamedObjectTest.java
+++ b/src/test/java/net/imagej/legacy/plugin/IJ1MacroLanguageNamedObjectTest.java
@@ -1,0 +1,171 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2020 ImageJ developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.plugin;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.object.ObjectService;
+import org.scijava.script.ScriptLanguage;
+import org.scijava.script.ScriptModule;
+import org.scijava.script.ScriptService;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests whether {@link IJ1MacroLanguage} works conveniently with named Objects present in the {@link ObjectService}
+ *
+ * This test works in combination with {@link MacroRecorderPostprocessorNamedObjectTest}
+ *
+ * Extra : groovy : should return the Object while in IJ1
+ *
+ * TODO : how to deal with duplicate names ? In terms of testing ?
+ *
+ * @author Nicolas Chiaruttini
+ */
+
+public class IJ1MacroLanguageNamedObjectTest {
+
+	private Context context;
+	private ScriptService scriptService;
+	private ObjectService objectService;
+
+	@Before
+	public void setUp() {
+		context = new Context();
+		scriptService = context.service(ScriptService.class);
+		objectService = context.service(ObjectService.class);
+	}
+
+	@After
+	public void tearDown() {
+		context.dispose();
+	}
+
+	@Test
+	public void testGroovyNamedObject() throws InterruptedException,
+			ExecutionException
+	{
+		// Puts a named Pet object into the ObjectService
+		Pet pet = new Pet("Felix", "Cat");
+		objectService.addObject(pet,pet.getName());
+
+		// Makes Pet class easily discoverable be the script service
+		scriptService.addAlias(Pet.class);
+
+		// Execute a script.
+		final String script = "" + //
+				"#@ Pet animal\n" + //
+				"#@ ObjectService objectService\n" + //
+				"#@output String greeting\n" + //
+				"greeting = 'Oh, '+objectService.getName(animal)+' is so cute!'\n" + //
+				"";
+
+		final ScriptModule m = scriptService.run("greet.groovy", script, true, //
+				"animal", "Felix").get(); // Felix is given -> needs String to Pet conversion
+
+		final Object returnValue = m.getReturnValue();
+
+		// Verify that the input has been found - felix the cat
+		// Correct class
+		assertSame(m.getInput("animal").getClass(), Pet.class);
+		// Correct instance
+		assertSame(m.getInput("animal"), pet);
+
+		// Verify that the script executed correctly - with the correct object being
+		// given to the script (groovy behaviour)
+		assertEquals("Oh, Felix is so cute!", //
+				m.getOutput("greeting"));
+
+	}
+
+
+	@Test
+	public void testIJ1MacroLanguageNamedObject() throws InterruptedException,
+			ExecutionException
+	{
+		// Puts a named Pet object into the ObjectService
+		Pet pet = new Pet("Felix", "Cat");
+		objectService.addObject(pet,pet.getName());
+
+		// Makes Pet class easily discoverable be the script service
+		scriptService.addAlias(Pet.class);
+
+		// Execute a script.
+		final String script = "" + //
+				"#@ Pet animal\n" + //
+				"#@output String greeting\n" + //
+				"greeting = 'Oh, '+animal+' is so cute!'\n" + //
+				"";
+
+		final ScriptModule m = scriptService.run("greet.ijm", script, true, //
+				"animal", pet).get();
+
+		final Object returnValue = m.getReturnValue();
+
+		// Verify that the input has been found - felix the cat
+		// Correct class
+		assertSame(m.getInput("animal").getClass(), Pet.class);
+		// Correct instance
+		assertSame(m.getInput("animal"), pet);
+
+		// Verify that the script executed correctly - with the correct object NAME being
+		// given to the script (IJ1 Macro Language behaviour)
+		assertEquals("Oh, Felix is so cute!", //
+				m.getOutput("greeting"));
+
+	}
+
+	/*
+		Simple "custom" object
+	 */
+	static class Pet {
+
+		private String name;
+
+		Pet(String name, String species) {
+			this.name = name;
+		}
+
+		// Unfortunately not a toString overriden method
+		public String getName() {
+			return name;
+		}
+
+	}
+
+}

--- a/src/test/java/net/imagej/legacy/plugin/IJ1MacroLanguageNamedObjectTest.java
+++ b/src/test/java/net/imagej/legacy/plugin/IJ1MacroLanguageNamedObjectTest.java
@@ -80,6 +80,7 @@ public class IJ1MacroLanguageNamedObjectTest {
 	public void testGroovyNamedObject() throws InterruptedException,
 			ExecutionException
 	{
+		// TODO : Do we want this behaviour with groovy ? But do we have a choice ?
 		// Puts a named Pet object into the ObjectService
 		Pet pet = new Pet("Felix", "Cat");
 		objectService.addObject(pet,pet.getName());

--- a/src/test/java/net/imagej/legacy/plugin/MacroRecorderPostprocessorNamedObjectIndexTest.java
+++ b/src/test/java/net/imagej/legacy/plugin/MacroRecorderPostprocessorNamedObjectIndexTest.java
@@ -1,0 +1,188 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2018 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.plugin;
+
+import net.imagej.legacy.IJ1Helper;
+import net.imagej.legacy.LegacyService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.module.Module;
+import org.scijava.module.process.AbstractPreprocessorPlugin;
+import org.scijava.module.process.PreprocessorPlugin;
+import org.scijava.object.ObjectService;
+import org.scijava.plugin.PluginInfo;
+import org.scijava.plugin.PluginService;
+import org.scijava.script.ScriptModule;
+import org.scijava.script.ScriptService;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests whether {@link MacroRecorderPostprocessor} uses the name of {@link NamedObjectIindex}
+ * in the MacroRecorder. This allows to conveniently use IJ1 MacroRecorder for objects present in the
+ * {@link ObjectService}, which do not have a proper overriden toString() method.
+ *
+ * @author Nicolas Chiaruttini
+ */
+public class MacroRecorderPostprocessorNamedObjectIndexTest {
+
+	private Context context;
+	private ScriptService scriptService;
+	private LegacyService legacyService;
+	private ObjectService objectService;
+
+	@Before
+	public void setUp() {
+		context = new Context();
+		scriptService = context.service(ScriptService.class);
+		legacyService = context.service(LegacyService.class);
+		objectService = context.service(ObjectService.class);
+	}
+
+	@After
+	public void tearDown() {
+		context.dispose();
+	}
+
+	@Test
+	public void testParametersRecorded() throws InterruptedException,
+		ExecutionException
+	{
+		// NB: Register a preprocessor that injects input values and resolves them.
+		// We need this, rather than passing the key/value pairs directly to the
+		// run method, because when you pass parameters directly to the module
+		// execution, they are immediately marked as resolved. But for the purposes
+		// of macro recording, we need the parameters to be _unresolved_ initially,
+		// and only later resolved around the time that input harvesting occurs.
+		context.service(PluginService.class).addPlugin(new PluginInfo<>(
+			MockInputHarvester.class, PreprocessorPlugin.class));
+
+		// NB: Override the IJ1Helper to remember which parameters get recorded.
+		final EideticIJ1Helper ij1Helper = new EideticIJ1Helper();
+		legacyService.setIJ1Helper(ij1Helper);
+
+		// Puts a Pet object into the ObjectService
+		Pet pet = new Pet("Felix", "Cat");
+		objectService.addObject(pet,pet.getName());
+
+		// Makes Pet class easily discoverable be the script service
+		scriptService.addAlias(Pet.class);
+
+		// Execute a script.
+		final String script = "" + //
+			"#@ Pet animal\n" + //
+			"#@ ObjectService objectService\n" + //
+			"#@output String greeting\n" + //
+			"greeting = 'Oh, '+objectService.getName(animal)+' is so cute!'\n" + //
+			"";
+
+		final ScriptModule m = //
+			scriptService.run("greet.groovy", script, true).get();
+
+		// Verify that Felix name is correctly registered in the ObjectService.
+		assertEquals("Felix", //
+					 objectService.getName(pet));
+
+		// Verify that the script executed correctly.
+		assertEquals("Oh, Felix is so cute!", //
+			m.getOutput("greeting"));
+
+		// Verify that the animal was recorded ...
+		assertEquals(1, ij1Helper.recordedArgs.size());
+
+		// ... with the named defined when added in the objectService
+		assertEquals("animal=Felix", ij1Helper.recordedArgs.get(0));
+	}
+
+	// -- Helper classes --
+
+	/**
+	 * Extended version of {@link IJ1Helper} that remembers recorded parameters.
+	 */
+	private class EideticIJ1Helper extends IJ1Helper {
+
+		public EideticIJ1Helper() {
+			super(legacyService);
+		}
+
+		private final List<String> recordedArgs = new ArrayList<>();
+		private boolean finished;
+
+		@Override
+		public void recordOption(final String key, final String value) {
+			if (finished) {
+				recordedArgs.clear();
+				finished = false;
+			}
+			recordedArgs.add(key + "=" + value);
+			super.recordOption(key, value);
+		}
+
+		@Override
+		public void finishRecording() {
+			super.finishRecording();
+			finished = true;
+		}
+	}
+
+	public static class MockInputHarvester extends AbstractPreprocessorPlugin {
+
+		@Override
+		public void process(final Module module) {
+			// Gets the first animal put in the objectService
+			Pet pet = this.context().getService(ObjectService.class).getObjects(Pet.class).get(0);
+			module.setInput("animal", pet);
+			module.resolveInput("animal");
+		}
+	}
+
+	static class Pet {
+
+		private String name;
+
+		Pet(String name, String species) {
+			this.name = name;
+		}
+
+		// Unfortunately not a toString overriden method
+		public String getName() {
+			return name;
+		}
+
+	}
+}

--- a/src/test/java/net/imagej/legacy/plugin/MacroRecorderPostprocessorNamedObjectTest.java
+++ b/src/test/java/net/imagej/legacy/plugin/MacroRecorderPostprocessorNamedObjectTest.java
@@ -53,13 +53,16 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests whether {@link MacroRecorderPostprocessor} uses the name of {@link NamedObjectIindex}
+ * Tests whether {@link MacroRecorderPostprocessor} uses the name of {@link org.scijava.object.NamedObjectIndex}
  * in the MacroRecorder. This allows to conveniently use IJ1 MacroRecorder for objects present in the
  * {@link ObjectService}, which do not have a proper overriden toString() method.
  *
+ * This class tests whether a Command being recorded outputs the correct name of an object, it works
+ * in combination with the test {@link IJ1MacroLanguageNamedObjectTest}.
+ *
  * @author Nicolas Chiaruttini
  */
-public class MacroRecorderPostprocessorNamedObjectIndexTest {
+public class MacroRecorderPostprocessorNamedObjectTest {
 
 	private Context context;
 	private ScriptService scriptService;
@@ -96,7 +99,7 @@ public class MacroRecorderPostprocessorNamedObjectIndexTest {
 		final EideticIJ1Helper ij1Helper = new EideticIJ1Helper();
 		legacyService.setIJ1Helper(ij1Helper);
 
-		// Puts a Pet object into the ObjectService
+		// Puts a named Pet object into the ObjectService
 		Pet pet = new Pet("Felix", "Cat");
 		objectService.addObject(pet,pet.getName());
 
@@ -115,6 +118,7 @@ public class MacroRecorderPostprocessorNamedObjectIndexTest {
 			scriptService.run("greet.groovy", script, true).get();
 
 		// Verify that Felix name is correctly registered in the ObjectService.
+		// TODO : is this necessary ? That's probably tested elsewhere
 		assertEquals("Felix", //
 					 objectService.getName(pet));
 
@@ -125,7 +129,7 @@ public class MacroRecorderPostprocessorNamedObjectIndexTest {
 		// Verify that the animal was recorded ...
 		assertEquals(1, ij1Helper.recordedArgs.size());
 
-		// ... with the named defined when added in the objectService
+		// ... with the recorder properly outputing the named defined when added in the objectService
 		assertEquals("animal=Felix", ij1Helper.recordedArgs.get(0));
 	}
 
@@ -171,6 +175,9 @@ public class MacroRecorderPostprocessorNamedObjectIndexTest {
 		}
 	}
 
+	/*
+		Simple "custom" object
+	 */
 	static class Pet {
 
 		private String name;


### PR DESCRIPTION
Hi all, and in particular @imagejan and @ctrueden,

This PR adds 2 tests, which, if passing, would improve IJ1 scripting recordability and execution.
The first one passes with the modification done in the commits, but not the second one.

* First one: checks whether, when one records a command, the name of the object specified in the objectService is used instead of the call in the toString method.

In practice, this gives:
```
run("myCommand", "animal=felix");
```
In the Macro Recorder, instead of:
```
run("myCommand", "animal=org.orga.unit.stuff.Pet@57a3e26a");
``` 

This works if one has put the object in the objectService using `objectService.add(new Pet(),"felix");`

* the second test is somehow the mirror of this. The idea, is that if one copy and paste `run("myCommand", "animal=felix");` in the script editor and launch it, that would work directly. 

However, I'm not sure at this point if that's possible in a 'generic' way. I guess the idea would be that if a String input cannot be resolved, even after looking through all the converters, one would have to look in the ObjectService whether there's a named object which fits the expected class. Such a mechanism should not be in legacy, and it looks like a strong change.

One thing which works currently is to write explicit converters from `String` to a specific class (here a `Converter<String, Pet>`. And we can probably live with that.

Last thing : even if an input would be resolved thanks to its `objectService.getName` String representation, the given input to the script should be different depending on the scripting language : the Object should be given for all languages, except in IJ1 Macro where you need to send a String. And ideally, this String should be  the one from `objectService.getName` instead of the one from `toString`.

I hope it's clear, that's of lot of things and I'm ready to spend some time on it, but I'd be pleased to have your inputs.
