### PR TITLE
IJ1Helper: Load icon via javax.imageio.ImageIO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ branches:
   - master
   - "/.*-[0-9]+\\..*/"
 install: true
+services:
+  - xvfb
 script: ".travis/build.sh"
 cache:
   directories:

--- a/src/main/java/net/imagej/legacy/IJ1Helper.java
+++ b/src/main/java/net/imagej/legacy/IJ1Helper.java
@@ -80,6 +80,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
+import javax.imageio.ImageIO;
 import javax.swing.SwingUtilities;
 
 import net.imagej.display.ImageDisplay;
@@ -189,8 +190,7 @@ public class IJ1Helper extends AbstractContextual {
 				ij1.setTitle(hooks.getAppName());
 				final URL iconURL = hooks.getIconURL();
 				if (iconURL != null) try {
-					final Object producer = iconURL.getContent();
-					final Image image = ij1.createImage((ImageProducer) producer);
+					final Image image = ImageIO.read(iconURL);
 					ij1.setIconImage(image);
 					if (IJ.isMacOSX()) try {
 						// NB: We also need to set the dock icon


### PR DESCRIPTION
This seems to fix a `java.lang.IllegalStateException: zip file closed` during ImageJ launch for me. 

Can others test if this works for them as well? @kephale @NicoKiaru 

The issue was mentioned [in the forum](https://forum.image.sc/t/error-using-imagejfunctions-show-from-uberjar-but-works-from-within-intellij/33185/7) and [on gitter](https://gitter.im/imagej/imagej?at=5ecf8762778fad0b132ffbe4).