### PR TITLE
Improve tests

### DIFF
--- a/src/test/java/net/imagej/legacy/LegacyOpenerTest.java
+++ b/src/test/java/net/imagej/legacy/LegacyOpenerTest.java
@@ -31,8 +31,7 @@ package net.imagej.legacy;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeTrue;
-
+import static org.junit.Assert.assertTrue;
 import java.net.URL;
 
 import net.imagej.patcher.LegacyInjector;
@@ -62,7 +61,7 @@ public class LegacyOpenerTest {
 	public void testPaulsMacro() throws Exception {
 		final URL url = getClass().getResource("/icons/imagej-256.png");
 		assertNotNull(url);
-		assumeTrue("file".equals(url.getProtocol()));
+		assertTrue("file".equals(url.getProtocol()));
 		final String path = url.getPath();
 		final String macro = "" + //
 			"// @OUTPUT int numResults\n" + //
@@ -107,7 +106,7 @@ public class LegacyOpenerTest {
 	public void testSliceLabels() throws Exception {
 		final URL url = getClass().getResource("/with-slice-label.tif");
 		assertNotNull(url);
-		assumeTrue("file".equals(url.getProtocol()));
+		assertTrue("file".equals(url.getProtocol()));
 
 		final String path = url.getPath();
 		final String macro = "" + //

--- a/src/test/java/net/imagej/legacy/LegacyServiceTest.java
+++ b/src/test/java/net/imagej/legacy/LegacyServiceTest.java
@@ -31,6 +31,7 @@ package net.imagej.legacy;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import ij.IJ;
@@ -76,7 +77,7 @@ public class LegacyServiceTest {
 		context = new Context(LegacyService.class);
 		final LegacyService legacyService =
 			context.getService(LegacyService.class);
-		assumeTrue(legacyService != null);
+		assertTrue(legacyService != null);
 
 		Context context2 = (Context)IJ.runPlugIn(Context.class.getName(), null);
 		assertNotNull(context2);
@@ -88,7 +89,7 @@ public class LegacyServiceTest {
 		context = new Context(LegacyService.class);
 		final LegacyService legacyService =
 			context.getService(LegacyService.class);
-		assumeTrue(legacyService != null);
+		assertTrue(legacyService != null);
 	}
 
 }

--- a/src/test/java/net/imagej/legacy/translate/ImagePlusCreatorTest.java
+++ b/src/test/java/net/imagej/legacy/translate/ImagePlusCreatorTest.java
@@ -118,7 +118,6 @@ public class ImagePlusCreatorTest
 		testArrayImage( UnsignedShortType::new, ShortProcessor.class );
 	}
 
-	@Ignore("currently broken")
 	@Test
 	public void testSignedShorts() {
 		testArrayImage( ShortType::new, FloatProcessor.class );
@@ -266,7 +265,6 @@ public class ImagePlusCreatorTest
 		assertArrayEquals( Arrays.copyOf( values, 2 ) , ((byte[]) processor.getPixels()) );
 	}
 
-	@Ignore("not working yet")
 	@Test
 	public void testCompositeImageLong() {
 		long[] values = { 1, 2, 3, 4 };


### PR DESCRIPTION
- Remove `@Ignore` annotation for two tests that actually pass.
- Replace `assumeTrue` by `assertTrue` in `LegacyServiceTest` and `LegacyOpenerTest`, as we want them to fail if the conditions aren't met.

Note that the usage of `assumeTrue(!GraphicsEnvironment.isHeadless());` in `SwitchToModernTest`, `RoiManagerPreprocessorTest` and `ShutdownTest` is unchanged, as this will lead to those tests being ignored when run in headless mode (i.e. on Travis CI).
