### PR TITLE
MacroPreprocessor: resolve Button type inputs

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/MacroPreprocessor.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroPreprocessor.java
@@ -40,6 +40,7 @@ import org.scijava.module.process.AbstractPreprocessorPlugin;
 import org.scijava.module.process.PreprocessorPlugin;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.widget.Button;
 
 /**
  * Populates the module's input values, when the command is invoked from an
@@ -67,12 +68,16 @@ public class MacroPreprocessor extends AbstractPreprocessorPlugin {
 		if (!ij1Helper.isMacro()) return;
 		for (final ModuleItem<?> input : module.getInfo().inputs()) {
 			final String name = input.getName();
+			final Class<?> type = input.getType();
 			final String value = ij1Helper.getMacroParameter(name);
 			if (value == null) {
 				// no macro parameter value provided
+				if (type.equals(Button.class)) {
+					// skip if input is a button
+					module.resolveInput(name);
+				}
 				continue;
 			}
-			final Class<?> type = input.getType();
 			if (!convertService.supports(value, type)) {
 				// cannot convert macro value into the input's actual type
 				continue;


### PR DESCRIPTION
When calling a command from a macro (with an option string), we usually don't want to show a UI dialog.

If the called command contains inputs of type `org.scijava.widget.Button`, we resolve these without setting them, as we assume that buttons and their callbacks provide some interactivity that is not required when running from macro.

See the closed PR https://github.com/imagej/imagej-legacy/pull/239 for some discussion.

---

I would have liked to respect a `required={false,true}` annotation for the `Button` input, but since `Button extends Optional`, `isRequired()` will *always* resolve to `false`, see also:

https://github.com/scijava/scijava-common/blob/46ca0d04c5c86eeb51f9daa9f130b0d7c8decd65/src/main/java/org/scijava/command/CommandModuleItem.java#L102-L106

---

I hope that this solution - while being a bit hacky - is less intrusive than #239, but still meets the requirements of the affected projects.

(/cc @frauzufall @NicoKiaru @tischi @romainGuiet @uschmidt83 @tferr)

Note 1: While in full-fledged scripting languages, you can always call `commandService.run("command",false, ...)` to avoid the automatic command preprocessing (and hence display of dialogs), this option doesn't exist in an IJ1 macro `run("...")` call.

Note 2: This pull request still allows commands whose dialog box is nothing else than a button to show a dialog box when invoked from the UI (scenario 1 in [this comment](https://github.com/imagej/imagej-legacy/pull/239#pullrequestreview-375238166) by @ctrueden).

Note 3: I tried to add a test for this behavior in https://github.com/imagej/imagej-legacy/commit/401cb9c85dc53646c4f8faced35a08d42d75bf4e, but it's not headless, as it seems this issue only occurs when running from a macro with the UI displayed. In addition, we still cannot distinguish between macro calls with and without option string (`run("Test Command")` vs. `run("Test Command", "")`, see also https://github.com/scijava/scijava-common/issues/317#issuecomment-364458528).