### PR TITLE
Add StringToResultsTableConverter

### DIFF
--- a/src/main/java/net/imagej/legacy/convert/StringToResultTableConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/StringToResultTableConverter.java
@@ -1,0 +1,52 @@
+package net.imagej.legacy.convert;
+
+import java.awt.Frame;
+import java.util.Collection;
+
+import org.scijava.Priority;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Plugin;
+
+import ij.WindowManager;
+import ij.measure.ResultsTable;
+import ij.text.TextWindow;
+
+@Plugin(type = Converter.class, priority = Priority.LOW)
+public class StringToResultTableConverter extends
+AbstractLegacyConverter<String, ResultsTable> {
+
+	@Override
+	public boolean canConvert(Object src, Class<?> dest) {
+		return super.canConvert(src, dest) && convert(src, getOutputType()) != null;
+	}
+
+	@Override
+	public <T> T convert(Object src, Class<T> dest) {
+		String title = (String) src;
+		@SuppressWarnings("unchecked")
+		T rt = (T) ResultsTable.getResultsTable(title);
+		return rt;
+	}
+
+	@Override
+	public void populateInputCandidates(Collection<Object> objects) {
+		Frame[] nonImageWindows = WindowManager.getNonImageWindows();
+		for (Frame frame : nonImageWindows) {
+			if (frame instanceof TextWindow) {
+				ResultsTable rt = ((TextWindow) frame).getTextPanel().getResultsTable();
+				if (rt != null) objects.add(rt);
+			}
+		}
+	}
+
+	@Override
+	public Class<String> getInputType() {
+		return String.class;
+	}
+
+	@Override
+	public Class<ResultsTable> getOutputType() {
+		return ResultsTable.class;
+	}
+
+}

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -102,6 +102,7 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.convert.ResultsTableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ROITreeToOverlayConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.StringToImagePlusConverter.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.StringToResultTableConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableListWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableToResultsTableConverters.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableUnwrapper.class.getName()) ||


### PR DESCRIPTION
This converter allows to get a `ResultsTable` by its title string. In addition, the `populateInputCandidates()` method allows to get a list of open results tables, e.g. to generate a choice dropdown in `ObjectWidget`.

Since we're using ImageJ1 classes directly, we need to add the new converter class to the exceptions in `ImageJ1EncapsulationTest`.

See also [this forum discussion](https://forum.image.sc/t/can-parameter-choices-annotation-be-filled-automatically/53753/5?u=imagejan).

To be discussed:
* It would be nice to extend the functionality to also allow loading `ResultsTable`s from files, using the static `ResultsTable.open(String path)` method (possibly delegating to a new `FileToResultsTableConverter`). I'll leave this to a future pull request.
* The current implementation of `ObjectWidget` and `ObjectService#getName()` returns the `ResultsTable`'s `toString()` value, resulting in a rather cryptic identifier in the dropdown choice:

  ```
  #@ ResultsTable (autoFill = false) rt
  ```

  ![image](https://user-images.githubusercontent.com/2033938/122391391-3efeb280-cf73-11eb-80df-b82d28602358.png)

  We could create a custom widget for `ResultsTable`, but I'd prefer using `ObjectWidget` to keep everything concise  (and staying with a converter has the added benefit that `#@` parameters are callable from CLI/macros right away). Maybe we can improve `ObjectService` somehow to be extensible via a (new) `NameProvider` plugin mechanism, but I'm not sure if this would be overdoing it? @ctrueden do you have some opinion/advice here?

