### PR TITLE
Expand plugins-config support

### DIFF
--- a/src/main/java/net/imagej/legacy/DefaultLegacyHooks.java
+++ b/src/main/java/net/imagej/legacy/DefaultLegacyHooks.java
@@ -341,7 +341,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 		// Note that we currently ignore line separator lines such as:
 		// Plugins>Image5D, "-"
 		final Pattern pattern = Pattern.compile(
-			"^\\s*([^,]*),\\s*\"([^\"]*)\",\\s*([^\\s]*(\\(.*\\))?)");
+			"^\\s*([^,]*),\\s*\"([^\"]*)\",\\s*([^\\s]*(\\(.*\\))?)\\s*");
 		final ClassLoader cl = Thread.currentThread().getContextClassLoader();
 		try {
 			final Enumeration<URL> pluginsConfigs = cl.getResources("plugins.config");


### PR DESCRIPTION
We were missing coverage of two valid plugin definitions in `plugins.config`:
* lines with trailing whitespace
* plugin invocations with parentheses

This patch adds support for both.

Closes https://github.com/imagej/pyimagej/issues/133