### PR TITLE
Add converter from image titel to Dataset

### DIFF
--- a/src/main/java/net/imagej/legacy/convert/StringToDatasetConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/StringToDatasetConverter.java
@@ -1,0 +1,98 @@
+/*
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2022 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import ij.ImagePlus;
+import net.imagej.Dataset;
+import net.imglib2.util.Cast;
+import org.scijava.convert.AbstractConverter;
+import org.scijava.convert.ConvertService;
+import org.scijava.convert.Converter;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.util.Types;
+
+import java.lang.reflect.Type;
+
+/**
+ * Converts a string that matches an {@link ImagePlus} title or ID to {@link Dataset}.
+ * (The {@link ImagePlus} must be known to the {@link ij.WindowManager}. This
+ * means it must be visible)
+ * <p>
+ * Similar to {@link StringToImagePlusConverter} but output type is {@link Dataset}.
+ *
+ * @author Matthias Arzt
+ */
+@Plugin(type = Converter.class)
+public class StringToDatasetConverter
+	extends AbstractConverter<String, Dataset>
+{
+
+	@Parameter
+	ConvertService cs;
+
+	private final Converter<String, ImagePlus> toImagePlus =
+		new StringToImagePlusConverter();
+
+	@Override
+	public boolean canConvert(Object src, Type dest)
+	{
+		return canConvert(src, Types.raw(dest));
+	}
+
+	@Override
+	public boolean canConvert(Object src, Class<?> dest)
+	{
+		return super.canConvert(src, dest) &&
+			toImagePlus.canConvert(src, ImagePlus.class);
+	}
+
+	@Override
+	public <T> T convert(Object src, Class<T> dest)
+	{
+		if (!(src instanceof String) || !Dataset.class.equals(dest))
+			return null;
+		ImagePlus imp = toImagePlus.convert(src, ImagePlus.class);
+		if (imp == null) return null;
+		return Cast.unchecked(cs.convert(imp, Dataset.class));
+	}
+
+	@Override
+	public Class<String> getInputType()
+	{
+		return String.class;
+	}
+
+	@Override
+	public Class<Dataset> getOutputType()
+	{
+		return Dataset.class;
+	}
+}

--- a/src/main/java/net/imagej/legacy/convert/StringToImagePlusConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/StringToImagePlusConverter.java
@@ -104,29 +104,4 @@ public class StringToImagePlusConverter extends
 		return String.class;
 	}
 
-	// -- Helper classes --
-
-	/**
-	 * Adapter for {@link ImagePlus} that emits the image title when
-	 * {@link #toString()} is called.
-	 *
-	 * @author Curtis Rueden
-	 */
-	public static class ImageTitle {
-
-		private final ImagePlus imp;
-
-		public ImageTitle(final ImagePlus imp) {
-			this.imp = imp;
-		}
-
-		// -- Object methods --
-
-		@Override
-		public String toString() {
-			return imp.getTitle();
-		}
-
-	}
-
 }

--- a/src/main/java/net/imagej/legacy/convert/StringToImagePlusConverter.java
+++ b/src/main/java/net/imagej/legacy/convert/StringToImagePlusConverter.java
@@ -32,9 +32,13 @@ package net.imagej.legacy.convert;
 import ij.ImagePlus;
 import ij.WindowManager;
 
+import net.imglib2.util.Cast;
 import org.scijava.convert.AbstractConverter;
 import org.scijava.convert.Converter;
 import org.scijava.plugin.Plugin;
+import org.scijava.util.Types;
+
+import java.lang.reflect.Type;
 
 /**
  * Converts a string to the corresponding {@link ImagePlus} object. Both image
@@ -69,29 +73,30 @@ public class StringToImagePlusConverter extends
 
 	@Override
 	public boolean canConvert(final Object src, final Class<?> dest) {
-		return convert(src, ImagePlus.class) != null;
+		return canConvert(src, (Type) dest);
+	}
+
+	@Override
+	public boolean canConvert(final Object src, final Type dest) {
+		return convert(src, Types.raw(dest)) != null;
 	}
 
 	@Override
 	public <T> T convert(final Object src, final Class<T> dest) {
-		if (!(src instanceof String)) return null;
+		if (!super.canConvert(src, dest))
+			return null;
 		final String s = (String) src;
 		try {
 			final int imageID = Integer.parseInt(s);
 			final ImagePlus imp = WindowManager.getImage(imageID);
 			if (imp != null) {
-				@SuppressWarnings("unchecked")
-				final T typedImp = (T) imp;
-				return typedImp;
+				return Cast.unchecked(imp);
 			}
 		}
 		catch (final NumberFormatException exc) {
 			// NB: Not a valid image ID; try image title.
 		}
-		final ImagePlus imp = WindowManager.getImage(s);
-		@SuppressWarnings("unchecked")
-		final T typedImp = (T) imp;
-		return typedImp;
+		return Cast.unchecked( WindowManager.getImage(s) );
 	}
 
 	@Override

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -101,6 +101,7 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.convert.ResultsTableWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.ROITreeToOverlayConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.StringToImagePlusConverter.class.getName()) ||
+					className.startsWith(net.imagej.legacy.convert.StringToDatasetConverter.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableListWrapper.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableToResultsTableConverters.class.getName()) ||
 					className.startsWith(net.imagej.legacy.convert.TableUnwrapper.class.getName()) ||

--- a/src/test/java/net/imagej/legacy/convert/StringToDatasetConverterTest.java
+++ b/src/test/java/net/imagej/legacy/convert/StringToDatasetConverterTest.java
@@ -1,0 +1,145 @@
+/*
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2022 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import ij.IJ;
+import ij.ImagePlus;
+import net.imagej.Dataset;
+import net.imagej.patcher.LegacyInjector;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.convert.ConvertService;
+import org.scijava.convert.Converter;
+
+import java.lang.reflect.Type;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests if an image title and ID can be converted to Dataset.
+ *
+ * @author Mattias Arzt
+ */
+public class StringToDatasetConverterTest {
+
+	static {
+		LegacyInjector.preinit();
+	}
+
+	private final String IMAGE_TITLE = "image title";
+	private final int PIXEL_VALUE = 45;
+
+	private Context context;
+	private ConvertService convertService;
+	private Converter<String, Dataset> converter;
+	private int imageId;
+
+	@Before
+	public void setUp() {
+		context = new Context();
+		convertService = context.service(ConvertService.class);
+		ImagePlus imp = IJ.createImage(IMAGE_TITLE, 10, 10, 1, 8);
+		imp.getProcessor().set(0, 0, PIXEL_VALUE);
+		imp.show();
+		imageId = imp.getID();
+		converter = convertService.getInstance(StringToDatasetConverter.class);
+	}
+
+	@After
+	public void teardown() {
+		context.dispose();
+	}
+
+	/**
+	 * Tests {@link StringToDatasetConverter#convert(Object, Class)}
+	 */
+	@Test
+	public void testConvertTitle() {
+		Dataset dataset = convertService.convert(IMAGE_TITLE, Dataset.class);
+		assertEquals(PIXEL_VALUE, dataset.getAt(0, 0).getRealDouble(), 0.0);
+	}
+
+	@Test
+	public void testConvertId() {
+		Dataset dataset =
+			convertService.convert(String.valueOf(imageId), Dataset.class);
+		assertEquals(PIXEL_VALUE, dataset.getAt(0, 0).getRealDouble(), 0.0);
+	}
+
+	/**
+	 * Tests if the converter behaves as expected when the string does not
+	 * match any image title.
+	 */
+	@Test
+	public void testNonImageTitle()
+	{
+		assertFalse(convertService.supports("no image", Dataset.class));
+		assertNull(convertService.convert("no image", Dataset.class));
+	}
+
+	/**
+	 * Test {@link StringToDatasetConverter#canConvert(Object, Class)}.
+	 */
+	@Test
+	public void testCanConvertTitle() {
+		assertTrue(converter.canConvert(IMAGE_TITLE, Dataset.class));
+		assertTrue(converter.canConvert(IMAGE_TITLE, Img.class));
+		assertTrue(
+			converter.canConvert(IMAGE_TITLE, RandomAccessibleInterval.class));
+		assertFalse(converter.canConvert(IMAGE_TITLE, ImagePlus.class));
+		assertFalse(converter.canConvert("no image", Dataset.class));
+	}
+
+	/**
+	 * Test {@link StringToDatasetConverter#canConvert(Object, Class)}.
+	 */
+	@Test
+	public void testCanConvertId() {
+		assertTrue(
+			converter.canConvert(String.valueOf(imageId), Dataset.class));
+
+		// NB: Should return false if the given number is not an image ID.
+		assertFalse(converter.canConvert("392847", Dataset.class));
+	}
+
+	/**
+	 * Test {@link StringToDatasetConverter#canConvert(Object, Type)}.
+	 */
+	@Test
+	public void testCanConvert2() {
+		assertTrue(converter.canConvert(IMAGE_TITLE, (Type) Dataset.class));
+		assertFalse(converter.canConvert(IMAGE_TITLE, (Type) ImagePlus.class));
+		assertFalse(converter.canConvert("no image", (Type) Dataset.class));
+	}
+}

--- a/src/test/java/net/imagej/legacy/convert/StringToDatasetConverterTest.java
+++ b/src/test/java/net/imagej/legacy/convert/StringToDatasetConverterTest.java
@@ -57,8 +57,9 @@ public class StringToDatasetConverterTest {
 		LegacyInjector.preinit();
 	}
 
-	private final String IMAGE_TITLE = "image title";
-	private final int PIXEL_VALUE = 45;
+	private final static String NON_IMAGE_TITLE = "no image";
+	private final static String IMAGE_TITLE = "image title";
+	private final static int PIXEL_VALUE = 45;
 
 	private Context context;
 	private ConvertService convertService;
@@ -104,8 +105,8 @@ public class StringToDatasetConverterTest {
 	@Test
 	public void testNonImageTitle()
 	{
-		assertFalse(convertService.supports("no image", Dataset.class));
-		assertNull(convertService.convert("no image", Dataset.class));
+		assertFalse(convertService.supports(NON_IMAGE_TITLE, Dataset.class));
+		assertNull(convertService.convert(NON_IMAGE_TITLE, Dataset.class));
 	}
 
 	/**
@@ -118,7 +119,7 @@ public class StringToDatasetConverterTest {
 		assertTrue(
 			converter.canConvert(IMAGE_TITLE, RandomAccessibleInterval.class));
 		assertFalse(converter.canConvert(IMAGE_TITLE, ImagePlus.class));
-		assertFalse(converter.canConvert("no image", Dataset.class));
+		assertFalse(converter.canConvert(NON_IMAGE_TITLE, Dataset.class));
 	}
 
 	/**
@@ -140,6 +141,6 @@ public class StringToDatasetConverterTest {
 	public void testCanConvert2() {
 		assertTrue(converter.canConvert(IMAGE_TITLE, (Type) Dataset.class));
 		assertFalse(converter.canConvert(IMAGE_TITLE, (Type) ImagePlus.class));
-		assertFalse(converter.canConvert("no image", (Type) Dataset.class));
+		assertFalse(converter.canConvert(NON_IMAGE_TITLE, (Type) Dataset.class));
 	}
 }

--- a/src/test/java/net/imagej/legacy/convert/StringToImagePlusConverterTest.java
+++ b/src/test/java/net/imagej/legacy/convert/StringToImagePlusConverterTest.java
@@ -58,7 +58,8 @@ public class StringToImagePlusConverterTest {
 		LegacyInjector.preinit();
 	}
 
-	private final String IMAGE_TITLE = "image title";
+	private final static String IMAGE_TITLE = "image title";
+	private final static String NON_IMAGE_TITLE = "no image";
 
 	private Context context;
 	private ConvertService convertService;
@@ -105,7 +106,7 @@ public class StringToImagePlusConverterTest {
 	@Test
 	public void testNonImageTitle()
 	{
-		assertFalse(convertService.getHandler("no image", ImagePlus.class)
+		assertFalse(convertService.getHandler(NON_IMAGE_TITLE, ImagePlus.class)
 			instanceof StringToImagePlusConverter);
 	}
 
@@ -116,7 +117,7 @@ public class StringToImagePlusConverterTest {
 	public void testCanConvertTitle() {
 		assertTrue(converter.canConvert(IMAGE_TITLE, ImagePlus.class));
 		assertFalse(converter.canConvert(IMAGE_TITLE, Dataset.class));
-		assertFalse(converter.canConvert("no image", ImagePlus.class));
+		assertFalse(converter.canConvert(NON_IMAGE_TITLE, ImagePlus.class));
 	}
 
 	/**
@@ -138,6 +139,6 @@ public class StringToImagePlusConverterTest {
 	public void testCanConvert2() {
 		assertTrue(converter.canConvert(IMAGE_TITLE, (Type) ImagePlus.class));
 		assertFalse(converter.canConvert(IMAGE_TITLE, (Type) Dataset.class));
-		assertFalse(converter.canConvert("no image", (Type) ImagePlus.class));
+		assertFalse(converter.canConvert(NON_IMAGE_TITLE, (Type) ImagePlus.class));
 	}
 }

--- a/src/test/java/net/imagej/legacy/convert/StringToImagePlusConverterTest.java
+++ b/src/test/java/net/imagej/legacy/convert/StringToImagePlusConverterTest.java
@@ -1,0 +1,143 @@
+/*
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2022 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.convert;
+
+import ij.IJ;
+import ij.ImagePlus;
+import net.imagej.Dataset;
+import net.imagej.ImgPlus;
+import net.imagej.patcher.LegacyInjector;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.convert.ConvertService;
+import org.scijava.convert.Converter;
+
+import java.lang.reflect.Type;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests if an image title and ID can be converted to ImagePlus.
+ *
+ * @author Mattias Arzt
+ */
+public class StringToImagePlusConverterTest {
+
+	static {
+		LegacyInjector.preinit();
+	}
+
+	private final String IMAGE_TITLE = "image title";
+
+	private Context context;
+	private ConvertService convertService;
+	private Converter<String, ImagePlus> converter;
+	private Object image;
+	private int imageId;
+
+	@Before
+	public void setUp() {
+		context = new Context();
+		convertService = context.service(ConvertService.class);
+		ImagePlus imp = IJ.createImage(IMAGE_TITLE, 10, 10, 1, 8);
+		imp.show();
+		image = imp;
+		imageId = imp.getID();
+		converter = convertService.getInstance(StringToImagePlusConverter.class);
+	}
+
+	@After
+	public void teardown() {
+		context.dispose();
+	}
+
+	/**
+	 * Tests {@link StringToImagePlusConverter#convert(Object, Class)}
+	 */
+	@Test
+	public void testConvertTitle() {
+		ImagePlus converted = convertService.convert(IMAGE_TITLE, ImagePlus.class);
+		assertEquals(image, converted);
+	}
+
+	@Test
+	public void testConvertId() {
+		ImagePlus converted =
+			convertService.convert(String.valueOf(imageId), ImagePlus.class);
+		assertEquals(image, converted);
+	}
+
+	/**
+	 * Tests if the converter behaves as expected when the string does not
+	 * match any image title.
+	 */
+	@Test
+	public void testNonImageTitle()
+	{
+		assertFalse(convertService.getHandler("no image", ImagePlus.class)
+			instanceof StringToImagePlusConverter);
+	}
+
+	/**
+	 * Test {@link StringToImagePlusConverter#canConvert(Object, Class)}.
+	 */
+	@Test
+	public void testCanConvertTitle() {
+		assertTrue(converter.canConvert(IMAGE_TITLE, ImagePlus.class));
+		assertFalse(converter.canConvert(IMAGE_TITLE, Dataset.class));
+		assertFalse(converter.canConvert("no image", ImagePlus.class));
+	}
+
+	/**
+	 * Test {@link StringToImagePlusConverter#canConvert(Object, Class)}.
+	 */
+	@Test
+	public void testCanConvertId() {
+		assertTrue(
+			converter.canConvert(String.valueOf(imageId), ImagePlus.class));
+
+		// NB: Should return false if the given number is not an image ID.
+		assertFalse(converter.canConvert("392847", ImagePlus.class));
+	}
+
+	/**
+	 * Test {@link StringToImagePlusConverter#canConvert(Object, Type)}.
+	 */
+	@Test
+	public void testCanConvert2() {
+		assertTrue(converter.canConvert(IMAGE_TITLE, (Type) ImagePlus.class));
+		assertFalse(converter.canConvert(IMAGE_TITLE, (Type) Dataset.class));
+		assertFalse(converter.canConvert("no image", (Type) ImagePlus.class));
+	}
+}


### PR DESCRIPTION
The newly added StringToDatasetConverter converts a String that matches an ImagePlus title or ID to Dataset. (The ImagePlus must be known to the WindowManager.)

This functionality is required to properly call a SciJava Commands with Dataset inputs from an IJ1 macro.

Fixes #246 