### PR TITLE
Fix batch mode for scijava commands that return a Dataset.

### DIFF
--- a/src/main/java/net/imagej/legacy/translate/Harmonizer.java
+++ b/src/main/java/net/imagej/legacy/translate/Harmonizer.java
@@ -179,6 +179,8 @@ public class Harmonizer extends AbstractContextual {
 		final ImagePlus imp)
 	{
 		final ImagePlus newImp = legacyService.getImageMap().registerDisplay(display);
+		if(imp == newImp)
+			return;
 		imp.setStack(newImp.getStack());
 		final int c = newImp.getNChannels();
 		final int z = newImp.getNSlices();

--- a/src/test/java/net/imagej/legacy/BatchModeTest.java
+++ b/src/test/java/net/imagej/legacy/BatchModeTest.java
@@ -1,3 +1,31 @@
+/*
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2022 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package net.imagej.legacy;
 
 import ij.IJ;
@@ -18,7 +46,7 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.UIService;
 
-import java.awt.*;
+import java.awt.GraphicsEnvironment;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assume.assumeFalse;
@@ -26,6 +54,8 @@ import static org.junit.Assume.assumeFalse;
 /**
  * Test if a {@link Command} that returns a {@link Dataset} behaves as expected
  * when a IJ1 macro is run in batch mode.
+ *
+ * @author Matthias Arzt
  */
 public class BatchModeTest {
 
@@ -37,12 +67,7 @@ public class BatchModeTest {
 
 	@Before
 	public void setUp() {
-		// only run the tests if a graphics environment is present
-		assumeFalse(GraphicsEnvironment.isHeadless());
-
 		context = new Context();
-		UIService service = context.service(UIService.class);
-		service.showUI();
 	}
 
 	@After
@@ -56,31 +81,39 @@ public class BatchModeTest {
 	public void testIJ1() {
 		WindowManager.closeAllWindows();
 		IJ.runMacro(
-			"setBatchMode(true);" +
-			"newImage(\"imageA\", \"8-bit black\", 2, 2, 1);" +
-			"newImage(\"imageB\", \"8-bit black\", 2, 2, 1);" +
-			"setBatchMode(\"exit & display\");"
+			"setBatchMode(true);\n" +
+			"newImage(\"imageA\", \"8-bit black\", 2, 2, 1);\n" +
+			"newImage(\"imageB\", \"8-bit black\", 2, 2, 1);\n" +
+			"run(\"Record Image Titles\");" +
+			"setBatchMode(false);"
 		);
-		assertArrayEquals(new String[] {"imageA", "imageB"}, WindowManager.getImageTitles());
+		assertArrayEquals(new String[] {"imageA", "imageB"}, RecordImageTitles.titles);
 	}
 
 	@Test
 	public void testBatchMode() {
+		showLegacyUI();
+
 		WindowManager.closeAllWindows();
 		IJ.runMacro(
 			"setBatchMode(true);" +
 			"run(\"Output Dataset\", \"title=imageA\");" +
 			"run(\"Output Dataset\", \"title=imageB\");" +
-			"setBatchMode(\"exit & display\");"
+			"run(\"Record Image Titles\");" +
+			"setBatchMode(false);"
 		);
-		assertArrayEquals(new String[] {"imageA", "imageB"}, WindowManager.getImageTitles());
+		assertArrayEquals(new String[] {"imageA", "imageB"}, RecordImageTitles.titles);
 	}
 
-	/**
-	 * Simple command that outputs a {@link Dataset}. Used for testing.
-	 *
-	 * @author Matthias Arzt
-	 */
+	private void showLegacyUI() {
+		// NB: The test fails, when the legacy ui is not visible.
+		// TODO: This should be improved. The test should also work in headless mode, without the legacy ui visible.
+		assumeFalse(GraphicsEnvironment.isHeadless());
+		UIService service = context.service(UIService.class);
+		service.showUI();
+	}
+
+	/** Simple command that outputs a {@link Dataset}. Used for testing. */
 	@Plugin(type = Command.class, menuPath = "ImageJ Legacy Test > Output Dataset")
 	public static class OutputDataset implements Command {
 
@@ -101,4 +134,15 @@ public class BatchModeTest {
 		}
 	}
 
+	/** Command the stores all image titles in a static field. Used for testing. */
+	@Plugin(type = Command.class, menuPath = "ImageJ Legacy Test > Record Image Titles")
+	public static class RecordImageTitles implements Command {
+
+		private static String[] titles;
+
+		@Override
+		public void run() {
+			titles = WindowManager.getImageTitles();
+		}
+	}
 }

--- a/src/test/java/net/imagej/legacy/BatchModeTest.java
+++ b/src/test/java/net/imagej/legacy/BatchModeTest.java
@@ -1,0 +1,97 @@
+package net.imagej.legacy;
+
+import ij.IJ;
+import ij.WindowManager;
+import net.imagej.Dataset;
+import net.imagej.DatasetService;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imagej.patcher.LegacyInjector;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.scijava.Context;
+import org.scijava.ItemIO;
+import org.scijava.command.Command;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.UIService;
+
+import static org.junit.Assert.assertArrayEquals;
+
+/**
+ * Test if a {@link Command} that returns a {@link Dataset} behaves as expected
+ * when a IJ1 macro is run in batch mode.
+ */
+public class BatchModeTest {
+
+	static {
+		LegacyInjector.preinit();
+	}
+
+	private Context context;
+
+	@Before
+	public void setUp() {
+		context = new Context();
+		UIService service = context.service(UIService.class);
+		service.showUI();
+	}
+
+	@After
+	public void tearDown() {
+		context.dispose();
+	}
+
+	/** Just for comparison, see how plain IJ1 behaves in batch mode. */
+	@Test
+	public void testIJ1() {
+		WindowManager.closeAllWindows();
+		IJ.runMacro(
+			"setBatchMode(true);" +
+			"newImage(\"imageA\", \"8-bit black\", 2, 2, 1);" +
+			"newImage(\"imageB\", \"8-bit black\", 2, 2, 1);" +
+			"setBatchMode(\"exit & display\");"
+		);
+		assertArrayEquals(new String[] {"imageA", "imageB"}, WindowManager.getImageTitles());
+	}
+
+	@Test
+	public void testBatchMode() {
+		WindowManager.closeAllWindows();
+		IJ.runMacro(
+			"setBatchMode(true);" +
+			"run(\"Output Dataset\", \"title=imageA\");" +
+			"run(\"Output Dataset\", \"title=imageB\");" +
+			"setBatchMode(\"exit & display\");"
+		);
+		assertArrayEquals(new String[] {"imageA", "imageB"}, WindowManager.getImageTitles());
+	}
+
+	/**
+	 * Simple command that outputs a {@link Dataset}. Used for testing.
+	 *
+	 * @author Matthias Arzt
+	 */
+	@Plugin(type = Command.class, menuPath = "ImageJ Legacy Test > Output Dataset")
+	public static class OutputDataset implements Command {
+
+		@Parameter
+		private DatasetService datasetService;
+
+		@Parameter(required = false)
+		public String title = "title";
+
+		@Parameter(type = ItemIO.OUTPUT)
+		public Dataset output;
+
+		@Override
+		public void run() {
+			output = datasetService
+				.create(new UnsignedByteType(), new long[] { 2, 2 }, title,
+					new AxisType[] { Axes.X, Axes.Y });
+		}
+	}
+
+}

--- a/src/test/java/net/imagej/legacy/BatchModeTest.java
+++ b/src/test/java/net/imagej/legacy/BatchModeTest.java
@@ -18,7 +18,10 @@ import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.UIService;
 
+import java.awt.*;
+
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Test if a {@link Command} that returns a {@link Dataset} behaves as expected
@@ -34,6 +37,9 @@ public class BatchModeTest {
 
 	@Before
 	public void setUp() {
+		// only run the tests if a graphics environment is present
+		assumeFalse(GraphicsEnvironment.isHeadless());
+
 		context = new Context();
 		UIService service = context.service(UIService.class);
 		service.showUI();
@@ -41,7 +47,8 @@ public class BatchModeTest {
 
 	@After
 	public void tearDown() {
-		context.dispose();
+		if(context != null)
+			context.dispose();
 	}
 
 	/** Just for comparison, see how plain IJ1 behaves in batch mode. */


### PR DESCRIPTION
* Add a test to check if a scijava command behaves as expected in batch
  mode.
* Tiny change to the method `rebuildImagePlusData` in the class `Harmonizer`.

fixes #215