### PR TITLE
Fix assertImageEquals to actually assert

### DIFF
--- a/src/test/java/net/imagej/test/AssertImgs.java
+++ b/src/test/java/net/imagej/test/AssertImgs.java
@@ -51,7 +51,7 @@ public class AssertImgs
 			RandomAccessibleInterval< ? extends ValueEquals< T > > expected,
 			RandomAccessibleInterval< T > actual )
 	{
-		pairedForEach( expected, actual, ValueEquals::valueEquals );
+		assertImageEquals( expected, actual, ValueEquals::valueEquals );
 	}
 
 	public static void assertRealTypeImageEquals(


### PR DESCRIPTION
When using `pairedForEach` directly, `assertImageEquals(RAI, RAI)` would never assert anything.
We need to call the three-argument signature `assertImageEquals(RAI, RAI, BiPredicate)` that adds the assertion.

I discovered this when using `AssertImgs` from my project:

```
		<dependency>
			<groupId>net.imagej</groupId>
			<artifactId>imagej-legacy</artifactId>
			<classifier>tests</classifier>
			<version>${imagej-legacy.version}</version>
			<scope>test</scope>
		</dependency>
```

... when I wanted to assert that two different images are actually _failing_ the test, which was not the case. Using `assertRealTypeImageEquals` is my workaround for now.
