### PR TITLE
Replace Thread.currentThread().getContextClassLoader

### DIFF
--- a/src/main/java/net/imagej/legacy/DefaultLegacyHooks.java
+++ b/src/main/java/net/imagej/legacy/DefaultLegacyHooks.java
@@ -342,7 +342,7 @@ public class DefaultLegacyHooks extends LegacyHooks {
 		// Plugins>Image5D, "-"
 		final Pattern pattern = Pattern.compile(
 			"^\\s*([^,]*),\\s*\"([^\"]*)\",\\s*([^\\s]*(\\(.*\\))?)\\s*");
-		final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+		final ClassLoader cl = Context.getClassLoader();
 		try {
 			final Enumeration<URL> pluginsConfigs = cl.getResources("plugins.config");
 			while (pluginsConfigs.hasMoreElements()) {

--- a/src/main/java/net/imagej/legacy/LegacyService.java
+++ b/src/main/java/net/imagej/legacy/LegacyService.java
@@ -55,6 +55,7 @@ import net.imagej.patcher.LegacyEnvironment;
 import net.imagej.patcher.LegacyInjector;
 import net.imagej.ui.viewer.image.ImageDisplayViewer;
 
+import org.scijava.Context;
 import org.scijava.Identifiable;
 import org.scijava.MenuPath;
 import org.scijava.Priority;
@@ -453,7 +454,7 @@ public final class LegacyService extends AbstractService implements
 				// Install the default legacy hooks before ImageJ 1.x initializes.
 				// Otherwise, the legacy hooks that fire during IJ1 initialization
 				// won't include DefaultLegacyHooks overrides of EssentialLegacyHooks.
-				final ClassLoader loader = Thread.currentThread().getContextClassLoader();
+				final ClassLoader loader = Context.getClassLoader();
 				ij1Helper = new IJ1Helper(this);
 				LegacyInjector.installHooks(loader, //
 					new DefaultLegacyHooks(this, ij1Helper));
@@ -518,7 +519,7 @@ public final class LegacyService extends AbstractService implements
 		ij1Helper.dispose();
 
 		synchronized (LegacyService.class) {
-			final ClassLoader loader = Thread.currentThread().getContextClassLoader();
+			final ClassLoader loader = Context.getClassLoader();
 			LegacyInjector.installHooks(loader, null);
 			instance = null;
 		}
@@ -799,7 +800,7 @@ public final class LegacyService extends AbstractService implements
 	@Deprecated
 	public static void preinit() {
 		try {
-			getLegacyEnvironment(Thread.currentThread().getContextClassLoader());
+			getLegacyEnvironment(Context.getClassLoader());
 		}
 		catch (final Throwable t) {
 			t.printStackTrace();

--- a/src/test/java/net/imagej/legacy/ShutdownTest.java
+++ b/src/test/java/net/imagej/legacy/ShutdownTest.java
@@ -69,7 +69,7 @@ public class ShutdownTest {
 
 		// NB: Save a reference to the context class loader _before_ the test.
 		// This will help avoid class loaders bleeding from one test to another.
-		originalLoader = Thread.currentThread().getContextClassLoader();
+		originalLoader = Context.getClassLoader();
 
 		context = new Context(LegacyService.class, UIService.class);
 	}


### PR DESCRIPTION
Context.getClassLoader() does the same thing, but has an appropriate fallback when Thread.currentThread().getContextClassLoader() is null.

This was causing issues leading to https://github.com/imagej/napari-imagej/issues/24