### PR TITLE
Use new default ImageDisplayService methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,8 @@
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
+
+		<imagej-common.version>2.0.1</imagej-common.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/net/imagej/legacy/display/LegacyImageDisplayService.java
+++ b/src/main/java/net/imagej/legacy/display/LegacyImageDisplayService.java
@@ -123,32 +123,6 @@ public class LegacyImageDisplayService extends AbstractService implements
 	}
 
 	@Override
-	public Dataset getActiveDataset() {
-		// Always want to go check the current ImagePlus
-		return getActiveDataset(getActiveImageDisplay());
-	}
-
-	@Override
-	public DatasetView getActiveDatasetView() {
-		return imageDisplayService().getActiveDatasetView();
-	}
-
-	@Override
-	public Position getActivePosition() {
-		return imageDisplayService().getActivePosition();
-	}
-
-	@Override
-	public Dataset getActiveDataset(final ImageDisplay display) {
-		return imageDisplayService().getActiveDataset(display);
-	}
-
-	@Override
-	public DatasetView getActiveDatasetView(final ImageDisplay display) {
-		return imageDisplayService().getActiveDatasetView(display);
-	}
-
-	@Override
 	public List<ImageDisplay> getImageDisplays() {
 		// Register all ImagePlus instances. This will generate ensure no
 		// ImagePluses are missed by the standard getImageDisplays.
@@ -161,11 +135,6 @@ public class LegacyImageDisplayService extends AbstractService implements
 		}
 
 		return imageDisplayService().getImageDisplays();
-	}
-
-	@Override
-	public Position getActivePosition(final ImageDisplay display) {
-		return imageDisplayService().getActivePosition(display);
 	}
 
 	// -- Heleper methods --

--- a/src/main/java/net/imagej/legacy/plugin/ActiveImagePlusPreprocessor.java
+++ b/src/main/java/net/imagej/legacy/plugin/ActiveImagePlusPreprocessor.java
@@ -35,7 +35,7 @@ import ij.WindowManager;
 import ij.process.ImageProcessor;
 
 import net.imagej.Dataset;
-import net.imagej.display.process.ActiveDatasetPreprocessor;
+import net.imagej.display.process.ActiveImagePreprocessor;
 import net.imagej.legacy.LegacyService;
 
 import org.scijava.Priority;
@@ -47,7 +47,7 @@ import org.scijava.plugin.Plugin;
 /**
  * TODO: this class can be removed once {@link Dataset} and {@link ImagePlus}
  * conversion is done properly via wrapping. Until that point, it needs to run
- * before the {@link ActiveDatasetPreprocessor}.
+ * before the {@link ActiveImagePreprocessor}.
  * <p>
  * Assigns the active {@link ImagePlus} when there is one single unresolved
  * {@link ImagePlus} parameter. Hence, rather than a dialog prompting the user


### PR DESCRIPTION
If you open an `ImagePlus` in the legacy UI and then try to convert it to a `Dataset` (or `DatasetView`), you may not be able to do so depending on whether the method you call updates the `LegacyImageMap` first. Many of `LegacyImageDisplayService`'s just delegate to the `DefaultImageDisplayService`, which of course do not update the `LegacyImageMap`. Now, using the `default` methods of `ImageDisplayService`, all methods should end up updating the `LegacyImageMap`.

This PR requires imagej/imagej-common#105.