### PR TITLE
Create an OverlayDisplay for displaying Overlays

### DIFF
--- a/src/main/java/net/imagej/legacy/display/DefaultOverlayDisplay.java
+++ b/src/main/java/net/imagej/legacy/display/DefaultOverlayDisplay.java
@@ -1,0 +1,30 @@
+package net.imagej.legacy.display;
+
+import ij.gui.Overlay;
+import org.scijava.convert.ConvertService;
+import org.scijava.display.AbstractDisplay;
+import org.scijava.display.Display;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+@Plugin(type = Display.class)
+public class DefaultOverlayDisplay extends AbstractDisplay<Overlay> implements OverlayDisplay {
+
+	@Parameter
+	public ConvertService convert;
+
+	public DefaultOverlayDisplay() {
+		super(Overlay.class);
+	}
+
+	@Override
+	public boolean canDisplay(Object src) {
+		return convert.supports(src, Overlay.class);
+	}
+
+	@Override
+	public void display(Object src) {
+		super.display(convert.convert(src, Overlay.class));
+	}
+
+}

--- a/src/main/java/net/imagej/legacy/display/OverlayDisplay.java
+++ b/src/main/java/net/imagej/legacy/display/OverlayDisplay.java
@@ -1,0 +1,15 @@
+package net.imagej.legacy.display;
+
+import org.scijava.display.Display;
+
+import ij.gui.Overlay;
+
+/**
+ * Marker interface for {@link Display} implementations that will be displaying
+ * {@link Overlay}s.
+ *
+ * @author Gabriel Selzer
+ */
+public interface OverlayDisplay extends Display<Overlay> {
+	// This interface intentionally left blank.
+}

--- a/src/main/java/net/imagej/legacy/display/OverlayDisplayViewer.java
+++ b/src/main/java/net/imagej/legacy/display/OverlayDisplayViewer.java
@@ -38,15 +38,14 @@ import org.scijava.ui.viewer.AbstractDisplayViewer;
 import org.scijava.ui.viewer.DisplayViewer;
 import org.scijava.ui.viewer.DisplayWindow;
 
-import ij.ImagePlus;
+import ij.gui.Overlay;
 import net.imagej.legacy.ui.LegacyUI;
 
 /**
- * {@link DisplayViewer} implementation for {@link ImagePlus}. Compatible with
+ * {@link DisplayViewer} implementation for {@link Overlay}. Compatible with
  * the {@link LegacyUI}.
  * 
- * @author Mark Hiner
- * @author Curtis Rueden
+ * @author Gabriel Selzer
  */
 @Plugin(type = DisplayViewer.class)
 public class OverlayDisplayViewer extends AbstractDisplayViewer<Overlay> {

--- a/src/main/java/net/imagej/legacy/display/OverlayDisplayViewer.java
+++ b/src/main/java/net/imagej/legacy/display/OverlayDisplayViewer.java
@@ -1,0 +1,88 @@
+/*
+ * #%L
+ * ImageJ2 software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2023 ImageJ2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.legacy.display;
+
+import ij.WindowManager;
+import ij.gui.Overlay;
+import org.scijava.display.Display;
+import org.scijava.plugin.Plugin;
+import org.scijava.ui.UserInterface;
+import org.scijava.ui.viewer.AbstractDisplayViewer;
+import org.scijava.ui.viewer.DisplayViewer;
+import org.scijava.ui.viewer.DisplayWindow;
+
+import ij.ImagePlus;
+import net.imagej.legacy.ui.LegacyUI;
+
+/**
+ * {@link DisplayViewer} implementation for {@link ImagePlus}. Compatible with
+ * the {@link LegacyUI}.
+ * 
+ * @author Mark Hiner
+ * @author Curtis Rueden
+ */
+@Plugin(type = DisplayViewer.class)
+public class OverlayDisplayViewer extends AbstractDisplayViewer<Overlay> {
+
+	// -- Internal AbstractDisplayViewer methods --
+
+	@Override
+	protected void updateTitle() {
+		// NB: Let's not mess with the ImagePlus title.
+	}
+
+	// -- DisplayViewer methods --
+
+	@Override
+	public boolean isCompatible(final UserInterface ui) {
+		return ui instanceof LegacyUI;
+	}
+
+	@Override
+	public boolean canView(final Display<?> d) {
+		return d instanceof OverlayDisplay;
+	}
+
+	@Override
+	public void view(final UserInterface ui, final Display<?> d) {
+		// NB: Do not create any DisplayWindow!
+		view((DisplayWindow) null, d);
+		d.update();
+	}
+
+	@Override
+	public void view(final DisplayWindow w, final Display<?> d) {
+		super.view(w, d);
+		final OverlayDisplay display = (OverlayDisplay) d;
+		for (final Overlay overlay : display) {
+			WindowManager.getCurrentImage().setOverlay(overlay);
+		}
+	}
+}

--- a/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
+++ b/src/test/java/net/imagej/legacy/ImageJ1EncapsulationTest.java
@@ -159,6 +159,7 @@ public class ImageJ1EncapsulationTest {
 					className.startsWith(net.imagej.legacy.display.ImagePlusDisplayViewer.class.getName()) ||
 					className.startsWith(net.imagej.legacy.display.LegacyImageDisplayService.class.getName()) ||
 					className.startsWith(net.imagej.legacy.display.LegacyImageDisplayViewer.class.getName()) ||
+					className.startsWith(net.imagej.legacy.display.OverlayDisplayViewer.class.getName()) ||
 					className.startsWith(net.imagej.legacy.plugin.ActiveImagePlusPreprocessor.class.getName()) ||
 					className.startsWith(net.imagej.legacy.plugin.DefaultLegacyOpener.class.getName()) ||
 					className.startsWith(net.imagej.legacy.plugin.IJ1MacroEngine.class.getName()) ||


### PR DESCRIPTION
Sometimes you have an Overlay (or a ROITree) without a backing image - this happens in napari, where the Shapes layers are completely disconnected from "image" data - and you want to display it in the original ImageJ UI - this new OverlayDisplay/OverlayDisplayViewer should do the trick