### PR TITLE
Fix windows test with maven-surefire-plugin 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,10 @@
 		<license.projectName>ImageJ2 software for multidimensional image processing and analysis.</license.projectName>
 		<license.excludes>**/script_templates/**,**/doc/**</license.excludes>
 
+		<!-- NB: Required for tests to pass on Windows CLI. -->
+		<!-- see https://github.com/imagej/imagej-legacy/issues/198 -->
+		<maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 	</properties>


### PR DESCRIPTION
Fixes the MacroTest.testBarePluginFromMacro failure on Windows.

NB: this test still fails with Java 11 even with this fix (with the same failure and error message), but passes with Java 8.

Closes #198