### PR TITLE
revisited the DefaultLegacyOpener, added support for SelfShowableContent

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/DefaultLegacyOpener.java
+++ b/src/main/java/net/imagej/legacy/plugin/DefaultLegacyOpener.java
@@ -63,6 +63,7 @@ import org.scijava.options.OptionsService;
 import org.scijava.plugin.Plugin;
 import org.scijava.plugin.PluginService;
 import org.scijava.service.Service;
+import org.scijava.ui.SelfShowableContent;
 
 /**
  * The default {@link LegacyOpener} plugin.
@@ -200,6 +201,10 @@ public class DefaultLegacyOpener implements LegacyOpener {
 	private Object handleData(Context c, Object data, String path, boolean displayResult) {
 		if (data == null) return path;
 
+		if (displayResult && data instanceof SelfShowableContent) {
+			((SelfShowableContent)data).show();
+			return data;
+		}
 		if (data instanceof Dataset) {
 			final Dataset d = (Dataset) data;
 			ImagePlus imp = null;


### PR DESCRIPTION
This PR solves two things:

Based on @ctrueden 's commit, it reorganizes the order of actions in the main ImageJ1&2 opening routine such that the routine first makes sure it has a valid argument (which is a "path" to a resource, be it a file on a drive, or URL to somewhere) and only then it continues resolving how that argument `path` is going to be opened. The constraints considered during the opening were preserved, that said, it still honors wether newStyleIO is to be used first or not, falls back to IJ openers, etc.

The second change is that it detects when an opener returns `SelfShowableContent` as a result of opening the input `path`, and if so, it activates its `show()` method...