### PR TITLE
Improvements in wrapping RealPointCollections

### DIFF
--- a/src/main/java/net/imagej/legacy/convert/roi/point/RealPointCollectionWrapper.java
+++ b/src/main/java/net/imagej/legacy/convert/roi/point/RealPointCollectionWrapper.java
@@ -36,6 +36,7 @@ import java.util.Iterator;
 import net.imagej.legacy.convert.roi.MaskPredicateWrapper;
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
+import net.imglib2.RealPositionable;
 import net.imglib2.roi.geom.real.WritableRealPointCollection;
 import net.imglib2.roi.util.RealLocalizableRealPositionable;
 import net.imglib2.roi.util.RealLocalizableRealPositionableWrapper;
@@ -100,12 +101,12 @@ public final class RealPointCollectionWrapper extends PointRoi implements
 
 	// -- Helper methods --
 
-	private static <L extends RealLocalizable> float[] getCoors(
-		final WritableRealPointCollection<RealLocalizableRealPositionable> rpc,
+	private static <L extends RealLocalizable & RealPositionable> float[] getCoors(
+		final WritableRealPointCollection<L> rpc,
 		final int d)
 	{
 		final FloatArray coor = new FloatArray();
-		final Iterator<RealLocalizableRealPositionable> itr = rpc.points()
+		final Iterator<L> itr = rpc.points()
 			.iterator();
 		while (itr.hasNext())
 			coor.addValue(itr.next().getFloatPosition(d));
@@ -113,10 +114,10 @@ public final class RealPointCollectionWrapper extends PointRoi implements
 		return coor.getArray();
 	}
 
-	private static <L extends RealLocalizable> int countPoints(
-		final WritableRealPointCollection<RealLocalizableRealPositionable> rpc)
+	private static <L extends RealLocalizable & RealPositionable> int countPoints(
+		final WritableRealPointCollection<L> rpc)
 	{
-		final Iterator<RealLocalizableRealPositionable> itr = rpc.points()
+		final Iterator<L> itr = rpc.points()
 			.iterator();
 		int count = 0;
 		while (itr.hasNext()) {

--- a/src/test/java/net/imagej/legacy/convert/roi/point/PointRoiConversionTest.java
+++ b/src/test/java/net/imagej/legacy/convert/roi/point/PointRoiConversionTest.java
@@ -71,7 +71,7 @@ import org.scijava.convert.Converter;
 public class PointRoiConversionTest {
 
 	private PointRoi point;
-	private WritableRealPointCollection<RealLocalizableRealPositionable> rpc;
+	private WritableRealPointCollection<RealPoint> rpc;
 	private WritableRealPointCollection<RealLocalizable> pointRoiWrap;
 	private PointRoi rpcWrap;
 	private ConvertService convertService;
@@ -80,16 +80,13 @@ public class PointRoiConversionTest {
 	public void setup() {
 		point = new PointRoi(new float[] { 12.125f, 17, 1 }, new float[] { -4, 6.5f,
 			30 });
-		final List<RealLocalizableRealPositionable> c = new ArrayList<>();
-		c.add(new RealLocalizableRealPositionableWrapper<>(new RealPoint(
-			new double[] { 12.125, -4 })));
-		c.add(new RealLocalizableRealPositionableWrapper<>(new RealPoint(
-			new double[] { 17, 6.5 })));
-		c.add(new RealLocalizableRealPositionableWrapper<>(new RealPoint(
-			new double[] { 1, 30 })));
+		final List<RealPoint> c = new ArrayList<>();
+		c.add(new RealPoint(12.125, -4));
+		c.add(new RealPoint(17, 6.5 ));
+		c.add(new RealPoint(1, 30));
 		rpc = new DefaultWritableRealPointCollection<>(c);
 		pointRoiWrap = new PointRoiWrapper(point);
-		rpcWrap = new RealPointCollectionWrapper(rpc);
+		rpcWrap = new RealPointCollectionWrapper<>(rpc, () -> new RealPoint(2));
 
 		final Context context = new Context(ConvertService.class);
 		convertService = context.service(ConvertService.class);
@@ -199,8 +196,7 @@ public class PointRoiConversionTest {
 
 		final float[] xp = p.getContainedFloatPoints().xpoints;
 		final float[] yp = p.getContainedFloatPoints().ypoints;
-		final Iterator<RealLocalizableRealPositionable> points = rpc.points()
-			.iterator();
+		final Iterator<RealPoint> points = rpc.points().iterator();
 		int count = 0;
 
 		while (points.hasNext()) {
@@ -215,6 +211,16 @@ public class PointRoiConversionTest {
 		assertEquals(rpc.realMin(1), p.getYBase(), 0);
 		assertEquals(rpc.realMax(0), p.getXBase() + p.getFloatWidth(), 0);
 		assertEquals(rpc.realMax(1), p.getYBase() + p.getFloatHeight(), 0);
+
+		// Add a new point in the wrapper and check for it in the wrapped object
+		p.addPoint(1.0, 1.0);
+		assertEquals(rpc.size(), 3);
+		((RealPointCollectionWrapper<?>) p).synchronize();
+		assertEquals(rpc.size(), 4);
+		Iterator<RealPoint> itr = rpc.points().iterator();
+		for (int i = 0; i < 3; i++)
+			itr.next();
+		assertEquals(new RealPoint(1, 1), itr.next());
 	}
 
 	@Test

--- a/src/test/java/net/imagej/legacy/convert/roi/point/PointRoiWrapperTest.java
+++ b/src/test/java/net/imagej/legacy/convert/roi/point/PointRoiWrapperTest.java
@@ -29,28 +29,31 @@
 
 package net.imagej.legacy.convert.roi.point;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import ij.IJ;
 import ij.ImagePlus;
 import ij.gui.PointRoi;
 
-import java.util.ArrayList;
+import java.util.*;
 import java.util.Iterator;
-import java.util.List;
 
-import net.imglib2.RealLocalizable;
-import net.imglib2.RealPoint;
+import net.imglib2.*;
+import net.imglib2.RandomAccess;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.interpolation.randomaccess.NearestNeighborInterpolatorFactory;
 import net.imglib2.roi.geom.real.DefaultWritableRealPointCollection;
 import net.imglib2.roi.geom.real.RealPointCollection;
 import net.imglib2.roi.geom.real.WritableRealPointCollection;
 
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.view.Views;
+import org.apache.commons.math3.analysis.interpolation.LinearInterpolator;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.*;
 
 /**
  * Tests {@link PointRoiWrapper}


### PR DESCRIPTION
With this immediate fix, the following SciJava script now runs (where before I got the same error described in #299):

The question now is whether we should further improve the type variables within `RealPoint` -> `PointRoi` conversions to be more correct.

```python
#@ Dataset i
#@output Dataset out

from java.util import ArrayList
from net.imglib2 import RealPoint
from net.imagej.roi import DefaultROITree
from net.imglib2.roi.geom.real import DefaultWritableRealPointCollection

arr = ArrayList([RealPoint([10, 10])])
pc = DefaultWritableRealPointCollection(arr)

tree = DefaultROITree()
tree.addROIs(ArrayList([pc]))
i.getProperties().put("rois", tree)

out = i
```

Closes #299