### PR TITLE
Update Process_Folder.ijm

### DIFF
--- a/src/main/resources/script_templates/ImageJ_1.x/Batch/Process_Folder.ijm
+++ b/src/main/resources/script_templates/ImageJ_1.x/Batch/Process_Folder.ijm
@@ -13,11 +13,13 @@ processFolder(input);
 
 // function to scan folders/subfolders/files to find files with correct suffix
 function processFolder(input) {
+	if(endsWith(input, "/")) input = substring(input, 0, (lengthOf(input)-1));
+	if(!endsWith(input, "/") | !endsWith(input,"\\")) input = input + File.separator;
 	list = getFileList(input);
 	list = Array.sort(list);
 	for (i = 0; i < list.length; i++) {
-		if(File.isDirectory(input + File.separator + list[i]))
-			processFolder(input + File.separator + list[i]);
+		if(File.isDirectory(input + list[i]))
+			processFolder(input + list[i]);
 		if(endsWith(list[i], suffix))
 			processFile(input, output, list[i]);
 	}
@@ -26,6 +28,6 @@ function processFolder(input) {
 function processFile(input, output, file) {
 	// Do the processing here by adding your own code.
 	// Leave the print statements until things work, then remove them.
-	print("Processing: " + input + File.separator + file);
+	print("Processing: " + input + file);
 	print("Saving to: " + output);
 }


### PR DESCRIPTION
I have made some very minor changes to this (very useful) template. I wrote a whole [post](https://quantixed.org/2025/02/16/tips-from-the-blog-xvii-better-process-folder-template-in-fiji/) about why!

In brief:

1. it's confusing for new coders to have to use `open(input + File.separator + file);` in `processFile()` but only if there are files to be processed that are in subdirectories, otherwise `open(input + file);` works fine. This inconsistency trips up many folks.
2. the double slashes introduced by the template into the path maybe functional but are still a pain to deal with later on in an analysis pipeline.

It seems it was [decided](https://forum.image.sc/t/template-is-missing-file-separator-since-updated-with-script-parameters/5986/9) to keep the current format of this template. This PR fixes the template so that the double slashes are banished and people can just paste in their code without adding any File.separator shenanigans. There shouldn't be any back compatibility issues because this is only a template for _new code_.