### PR TITLE
Fix for imagej/imagej-legacy#239

### DIFF
--- a/src/main/java/net/imagej/legacy/plugin/MacroPreprocessor.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroPreprocessor.java
@@ -66,13 +66,21 @@ public class MacroPreprocessor extends AbstractPreprocessorPlugin {
 		if (ij1Helper == null) return;
 		if (!ij1Helper.isMacro()) return;
 		for (final ModuleItem<?> input : module.getInfo().inputs()) {
+			final Class<?> type = input.getType();
 			final String name = input.getName();
 			final String value = ij1Helper.getMacroParameter(name);
-			if (value == null) {
-				// no macro parameter value provided
+			if (ColorTable.class.equals(type) || ItemVisibility.MESSAGE.equals(input.getVisibility())) {
+				// resolve display messages and color tables. For the latter, a macro parameter
+				// value is provided but IJM cannot do anything with it. See #239 for details
+				module.resolveInput(name);
 				continue;
 			}
-			final Class<?> type = input.getType();
+			if (value == null) { // no macro parameter value provided
+				if (Button.class.equals(type)) {
+					module.resolveInput(name); // resolve buttons
+				}
+				continue;
+			}
 			if (!convertService.supports(value, type)) {
 				// cannot convert macro value into the input's actual type
 				continue;

--- a/src/main/java/net/imagej/legacy/plugin/MacroPreprocessor.java
+++ b/src/main/java/net/imagej/legacy/plugin/MacroPreprocessor.java
@@ -66,19 +66,17 @@ public class MacroPreprocessor extends AbstractPreprocessorPlugin {
 		if (ij1Helper == null) return;
 		if (!ij1Helper.isMacro()) return;
 		for (final ModuleItem<?> input : module.getInfo().inputs()) {
-			final Class<?> type = input.getType();
 			final String name = input.getName();
-			final String value = ij1Helper.getMacroParameter(name);
-			if (ColorTable.class.equals(type) || ItemVisibility.MESSAGE.equals(input.getVisibility())) {
-				// resolve display messages and color tables. For the latter, a macro parameter
+			final Class<?> type = input.getType();
+			if (Button.class.equals(type) || ColorTable.class.equals(type) || ItemVisibility.MESSAGE.equals(input.getVisibility())) {
+				// resolve buttons, display messages, and color tables. For the latter a parameter
 				// value is provided but IJM cannot do anything with it. See #239 for details
 				module.resolveInput(name);
 				continue;
 			}
-			if (value == null) { // no macro parameter value provided
-				if (Button.class.equals(type)) {
-					module.resolveInput(name); // resolve buttons
-				}
+			final String value = ij1Helper.getMacroParameter(name);
+			if (value == null) {
+				// no macro parameter value provided
 				continue;
 			}
 			if (!convertService.supports(value, type)) {


### PR DESCRIPTION
This extends imagej/imagej-legacy#262 further:
- Ignore Buttons (these are not recordable in ij.gui.GenericDialog, so this change _should_ not carry breaking changes)
- Ignore ColorTables (these are assigned a value parameter but IJM does not know what to do with it)
- Ignore inputs tagged w/ ItemVisibility.MESSAGE  (as per documentation:  this indicated that the item's value is intended as a message to the user rather than an actual parameter to the module execution)